### PR TITLE
newapkbuild: omit depends_dev if no *.h or *.hpp file found

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -207,6 +207,12 @@ __EOF__
 	done
 	echo "builddir=$builddir" >> APKBUILD
 
+	# Subpackage -dev is usually required only for C/C++. Since depends_dev
+	# confuses a lot people, remove it if there's no .h or .hpp file.
+	find "$sdir" -name "*.h" -o -name "*.hpp" -maxdepth 3 \
+		| head -n 1 | grep -q ".*" \
+		|| sed -i -e '/^depends_dev=.*/d' -e 's/\$depends_dev\s*//' APKBUILD
+
 	# Check if its autotools
 	if [ -z "$buildtype" ]; then
 		if [ -x "$sdir"/configure ]; then


### PR DESCRIPTION
EDIT: I’ve unintentionally pushed to GitHub, so it automatically closed this PR. I’ve immediately reverted it (using force push), but GitHub doesn’t allow to reopen pull request, so I’ve opened a new one: #6.
