### PR TITLE
abuild.in: fix dealing with named remote patches

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -556,7 +556,7 @@ getpkgver() {
 have_patches() {
 	local i
 	for i in $source; do
-		case "$i" in
+		case ${i%::*} in
 			*.patch) return 0;;
 		esac
 	done
@@ -570,10 +570,10 @@ default_prepare() {
 		return 0
 	fi
 	for i in $source; do
-		case $i in
+		case ${i%::*} in
 			*.patch)
-				msg "$i"
-				patch "${patch_args:--p1}" -i "$srcdir/$i" || return 1
+				msg "${i%::*}"
+				patch "${patch_args:--p1}" -i "$srcdir/${i%::*}" || return 1
 				;;
 		esac
 	done


### PR DESCRIPTION
for patches like:
patchname.patch::http://github/.../commit/md5hash.patch

use strict filename instead of the whole line