### PR TITLE
abuild: Check for ppc64le on config.guess

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -525,7 +525,7 @@ update_config_sub() {
 update_config_guess() {
 	local changed=false
 	find . -name config.guess | while read f; do
-		if grep -q aarch64 "$f"; then
+		if grep -q aarch64 "$f" && grep -q ppc64le "$f"; then
 			msg "No update needed for $f"
 		else
 			msg "Updating $f"


### PR DESCRIPTION
Currently, if aarch64 exists in config.guess, it is not updated.
This breaks spl, which has aarch64 entry, but not ppc64le.

update_config_guess should update config.guess if any of those
does not exists.