### PR TITLE
abuild: Add support for lzip source packages

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -418,6 +418,9 @@ default_unpack() {
 			*.tar.bz2)
 				msg "Unpacking $s..."
 				tar -C "$srcdir" -jxf "$s" || return 1;;
+			*.tar.lz)
+				msg "Unpacking $s..."
+				tar -C "$srcdir" --lzip -xf "$s" || return 1;;
 			*.tar.lzma)
 				msg "Unpacking $s..."
 				unlzma -c "$s" | tar -C "$srcdir" -x  \


### PR DESCRIPTION
Currently abuild does not understand .tar.lz packages, which blocks
the inclusion of certain packages in Alpine Linux.

I found this issue when adding 'ed' package to the repository. With
this change, abuild package will now depend on lzip package. I might
send a patch for abuild's APKBUILD.