### PR TITLE
Fix false `set -e` termination

### DIFF
--- a/functions.sh.in
+++ b/functions.sh.in
@@ -149,6 +149,7 @@ readconfig() {
 			export LDFLAGS="--sysroot=${CBUILDROOT} $LDFLAGS"
 		fi
 	fi
+	return 0
 }
 readconfig
 


### PR DESCRIPTION
`readconfig()` would return the result of `[ -z "$CBUILDROOT" ]` condition (line 123) and trigger shell termination in abuild.
This also fixes building packages with a different `$CTARGET` and therefore cross-compile tools.