### PR TITLE
abuild: add !checkroot option to run tests without fakeroot

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1401,6 +1401,9 @@ build_abuildrepo() {
 		# if package() is missing then build is called from rootpkg
 		_build=true
 	fi
+	if options_has "!checkroot"; then
+		_check=check
+	fi
 	if ! want_check; then
 		_check=true
 	fi


### PR DESCRIPTION
Due to fakeroot being very permissive with regards to file permissions, some package testsuites that explicitly check for failing permission checks will fail.

For those testsuites, give the APKBUILD the option to run the tests outside of a fakeroot environment.
