### PR TITLE
abuild-fetch.c: remove saveas- syntax

### DIFF
--- a/abuild-fetch.c
+++ b/abuild-fetch.c
@@ -84,9 +84,6 @@ int fetch(char *url, const char *destdir)
 		name = url;
 		*p = '\0';
 		url = p + 2;
-	} else if (strstr(url, "saveas-") == url) {
-		*name++ = '\0';
-		url += 7;  /* strlen("saveas-") */
 	} else {
 		name++;
 	}


### PR DESCRIPTION
As discussed in https://github.com/alpinelinux/aports/pull/1438