### PR TITLE
Add parameter '-D' for alternative APKINDEX description

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1437,6 +1437,7 @@ update_abuildrepo_index() {
 	done
 	subpkg_unset
 
+	[ -z "$DESCRIPTION" ] && DESCRIPTION="$repo $(cd $startdir && git describe || true)"
 	for i in $allarch; do
 		cd "$REPODEST/$repo/$i"
 		local index=$i/APKINDEX.tar.gz
@@ -1448,8 +1449,7 @@ update_abuildrepo_index() {
 			oldindex="--index APKINDEX.tar.gz"
 		fi
 		( $APK index --quiet $oldindex --output APKINDEX.tar.gz.$$ \
-			--description "$repo $(cd $startdir && git describe)" \
-			--rewrite-arch $i *.apk && \
+			--description "$DESCRIPTION" --rewrite-arch $i *.apk && \
 		  msg "Signing the index..." && \
 		  abuild-sign -q APKINDEX.tar.gz.$$ && \
 		  chmod 644 APKINDEX.tar.gz.$$ && \
@@ -2199,12 +2199,13 @@ snapshot() {
 usage() {
 	echo "$program $program_version"
 	cat <<-EOF
-		usage: $program [options] [-P REPODEST] [-s SRCDEST] [cmd] ...
+		usage: $program [options] [-P REPODEST] [-s SRCDEST] [-D DESCRIPTION] [cmd] ...
 		       $program [-c] -n PKGNAME[-PKGVER]
 		Options:
 		 -A  Print CARCH and exit
 		 -c  Enable colored output
 		 -d  Disable dependency checking
+		 -D  Set APKINDEX description (default: \$repo \$(git describe))
 		 -f  Force specified cmd, even if they are already done
 		 -F  Force run as root
 		 -h  Show this help
@@ -2254,12 +2255,13 @@ usage() {
 APKBUILD="${APKBUILD:-./APKBUILD}"
 unset force
 unset recursive
-while getopts "AcdfFhkKimnp:P:qrRs:u" opt; do
+while getopts "AcdD:fFhkKimnp:P:qrRs:u" opt; do
 	case $opt in
 		'A') echo "$CARCH"; exit 0;;
 		'c') enable_colors
 		     color_opt="-c";;
 		'd') nodeps="-d";;
+		'D') DESCRIPTION=$OPTARG;;
 		'f') force="-f";;
 		'F') forceroot="-F";;
 		'h') usage;;


### PR DESCRIPTION
This patch allows to set a nice description for the APKINDEX, in case
the aport that is being built is not inside a git repository.

I have tested it, and it behaves exactly like without the patch,
even when git is not installed, or the folder is not inside a git repository:
The `|| true` at the end of the DESCRIPTION= line makes sure, aport
does not get aborted, just like it does not get aborted in that case
as of now, as the `git describe` command gets executed in a subshell.