### PR TITLE
Merge Adélie changes into abuild

### DIFF
--- a/abuild-sign.in
+++ b/abuild-sign.in
@@ -31,7 +31,7 @@ do_sign() {
 		sig=".SIGN.RSA.$keyname"
 		openssl dgst -sha1 -sign "$privkey" -out "$sig" "$i"
 		tmptargz=$(mktemp)
-		tar -c "$sig" | abuild-tar --cut | gzip -9 > "$tmptargz"
+		tar -f - -c "$sig" | abuild-tar --cut | gzip -9 > "$tmptargz"
 		tmpsigned=$(mktemp)
 		cat "$tmptargz" "$i" > "$tmpsigned"
 		rm -f "$tmptargz" "$sig"

--- a/abuild.in
+++ b/abuild.in
@@ -2222,6 +2222,7 @@ usage() {
 		 -R  Recursively build and install missing dependencies (using sudo)
 		 -s  Set source package destination directory
 		 -u  Recursively build and upgrade all dependencies (using sudo)
+		 -v  Verbose: show every command as it is run (very noisy)
 
 		Commands:
 		  build       Compile and install package into \$pkgdir
@@ -2259,6 +2260,7 @@ APKBUILD="${APKBUILD:-./APKBUILD}"
 unset force
 unset recursive
 while getopts "AcdD:fFhkKimnp:P:qrRs:u" opt; do
+while getopts "AcdD:fFhkKimnp:P:qrRs:uv" opt; do
 	case $opt in
 		'A') echo "$CARCH"; exit 0;;
 		'c') enable_colors
@@ -2280,6 +2282,7 @@ while getopts "AcdD:fFhkKimnp:P:qrRs:u" opt; do
 		's') SRCDEST=$OPTARG;;
 		'u') upgrade="-u"
 		     recursive="-R";;
+		'v') set -x;;
 	esac
 done
 shift $(( $OPTIND - 1 ))

--- a/abuild.in
+++ b/abuild.in
@@ -1529,9 +1529,11 @@ doc() {
 	default_doc
 }
 
-# predefined splitfunc doc
+# predefined splitfunc dbg
 default_dbg() {
 	local f
+	pkgdesc="$pkgdesc (debug symbols)"
+
 	binfiles=$(scanelf -R "$pkgdir" | grep ET_DYN | sed "s:$pkgdir\/::g" | sed "s:ET_DYN ::g")
 	for f in $binfiles; do
 		srcdir=$(dirname $pkgdir/$f)

--- a/abuild.in
+++ b/abuild.in
@@ -1375,7 +1375,7 @@ create_apks() {
 			touch .dummy
 			set -- .dummy
 		fi
-		tar --xattrs -c "$@" | abuild-tar --hash | gzip -9 >"$dir"/data.tar.gz
+		tar --xattrs -f - -c "$@" | abuild-tar --hash | gzip -9 >"$dir"/data.tar.gz
 
 		msg "Create checksum..."
 		# append the hash for data.tar.gz
@@ -1384,7 +1384,7 @@ create_apks() {
 
 		# control.tar.gz
 		cd "$dir"
-		tar -c $(cat "$dir"/.metafiles) | abuild-tar --cut \
+		tar -f - -c $(cat "$dir"/.metafiles) | abuild-tar --cut \
 			| gzip -9 > control.tar.gz
 		abuild-sign -q control.tar.gz || exit 1
 

--- a/abuild.in
+++ b/abuild.in
@@ -2261,7 +2261,6 @@ usage() {
 APKBUILD="${APKBUILD:-./APKBUILD}"
 unset force
 unset recursive
-while getopts "AcdD:fFhkKimnp:P:qrRs:u" opt; do
 while getopts "AcdD:fFhkKimnp:P:qrRs:uv" opt; do
 	case $opt in
 		'A') echo "$CARCH"; exit 0;;

--- a/abuild.in
+++ b/abuild.in
@@ -1333,7 +1333,7 @@ scan_pkgconfig_depends() {
 human_size() {
 	awk '{  split("B KB MB GB TB PB", type)
 		for(i=5; y < 1 && $1 > 0; i--)
-			y = $1 / (2**(10*i))
+			y = $1 / (2^(10*i))
 		printf("%.1f %s\n", y, type[i+2]) }'
 }
 

--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -285,7 +285,8 @@ __EOF__
 usage() {
 	cat >&2 <<-__EOF__
 		$program $program_version - generate a new APKBUILD
-		Usage: $program [-cfh] [-d DESC] [-l LICENSE] [-n NAME] [-u URL]
+		Usage: $program [-n NAME] [-d DESC] [-l LICENSE] [-u URL]
+		       [-aCpy] [-s] [-cfh]
 		       PKGNAME[-PKGVER]|SRCURL
 		Options:
 		  -n  Set package name to NAME


### PR DESCRIPTION
Hi there,

These commits are the current abuild patches we are using in Adélie.  Most are simple portability or documentation fixes.  It also adds '-v' verbose option to abuild as discussed on IRC, as it seems like a lot of people need this (myself included).  That feature can be removed from this branch if it is not desired.