### PR TITLE
abuild.in: remove saveas- syntax and fix sourcecheck()

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -295,15 +295,11 @@ sourcecheck() {
 	for uri in $source; do
 		is_remote $uri || continue
 		case "$uri" in
-		saveas-*://*)
-			uri=${uri#saveas-}
-			uri=${uri%/*}
-			;;
 		*::*)
 			uri=${uri##*::}
 			;;
 		esac
-		wget -q -s "$uri" || return 1
+		wget --spider -q "$uri" || return 1
 	done
 	return 0
 }
@@ -318,7 +314,7 @@ uri_fetch() {
 
 is_remote() {
 	case "${1#*::}" in
-		http://*|ftp://*|https://*|saveas-*://*)
+		http://*|ftp://*|https://*)
 			return 0;;
 	esac
 	return 1


### PR DESCRIPTION
As discussed in alpinelinux/aports#1438
saveas- was removed from abuild-fetch.c with https://github.com/alpinelinux/abuild/pull/20 but abuild.in slipped.
Also fixes a wget -s instance that's not supported by recent busybox (-s was changed for --spider).
