### PR TITLE
August 2017 merge from Adélie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ abuild
 abuild-fetch
 abuild-gzsplit
 abuild-keygen
+abuild-rmtemp
 abuild-sign
 abuild-sudo
 abuild-tar

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 abuild
 abuild-fetch
+abuild-gzsplit
 abuild-keygen
 abuild-sign
 abuild-sudo

--- a/abuild-rmtemp.c
+++ b/abuild-rmtemp.c
@@ -4,6 +4,7 @@
  * Distributed under GPL-2
  */
 
+#define _XOPEN_SOURCE 700
 #include <err.h>
 #include <errno.h>
 #include <ftw.h>

--- a/abuild.in
+++ b/abuild.in
@@ -1838,6 +1838,10 @@ parse_aports_makedepends() {
 		for j in $pkgname $subpackages; do
 			echo "o ${j%%:*} $dir"
 			set -- $deps
+			if [ $# -eq 0 ]; then
+				echo "d ${j%%:*}"
+				continue
+			fi
 			echo -n "d ${j%%:*} $1"
 			shift
 			while [ $# -gt 0 ]; do


### PR DESCRIPTION
* Ignore all binaries in `.gitignore`
* Ensure POSIX portability for abuild
* Ensure POSIX portability for abuild-rmtemp.c (build fails on at least glibc due to FTW_DEPTH requiring _XOPEN_SOURCE)