### PR TITLE
Two patches for abuild

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -125,7 +125,7 @@ default_sanitycheck() {
 	[ -z "$pkgrel" ] && die "Missing pkgrel in APKBUILD"
 	[ -z "$pkgdesc" ] && die "Missing pkgdesc in APKBUILD"
 	[ -z "$url" ] && die "Missing url in APKBUILD"
-	[ -z "$license" ] && die "Missing license in APKBULID"
+	[ -z "$license" ] && die "Missing license in APKBUILD"
 	if [ $(echo "$pkgdesc" | wc -c) -gt 128 ]; then
 		die "pkgdesc is too long"
 	fi

--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -216,7 +216,7 @@ __EOF__
 			buildtype="perl"
 		elif [ -r "$sdir"/waf ]; then
 			buildtype="waf"
-		elif [ -d "$sdir"/cmake ]; then
+		elif [ -d "$sdir"/cmake ] || [ -r "$sdir/CMakeLists.txt" ]; then
 			buildtype="cmake"
 		elif [ -r "$sdir"/Makefile ]; then
 			buildtype="make"


### PR DESCRIPTION
Patch 1 corrects a typo in abuild.

Patch 2 lets the CMake detection work better.  This has been necessary for me packaging KDE software.