### PR TITLE
newapkbuild: use make 'package' phase for CMake as well

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -256,7 +256,7 @@ package() {
 __EOF__
 
 	case "$buildtype" in
-	make)
+	make|cmake)
 		package_make;;
 	autotools)
 		package_autotools;;


### PR DESCRIPTION
Right now no `package` phase is implemented for CMake packages.  It uses the same DESTDIR format as the make type since it generates Unix Makefiles so just use make package for CMake.