### PR TITLE
Make file missing in source var message more explicit.

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -214,7 +214,7 @@ default_sanitycheck() {
 		while [ $# -gt 1 ]; do
 			local file="$2"
 			shift 2
-			source_has $file || die "$file exists in ${algo}sums but is missing in source"
+			source_has $file || die "$file exists in ${algo}sums but is missing in \$source"
 		done
 	done
 


### PR DESCRIPTION
I've forgot to add a patch file to the source variable in an APKBUILD,
altought I did add it to the sums variable.

The error message made it
seem that I've forgot to add the file to the source directory, which led
me to check if my build system was missing the files for some reason.

Only after reading the `abuild.in` file did I understood what happened.

Hopefully this change makes the message clearer and more helpful.