### PR TITLE
-f (force): Only rebuild up to date packages

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -416,10 +416,8 @@ initdcheck() {
 # unpack the sources
 default_unpack() {
 	local u
-	if [ -z "$force" ]; then
-		verify || return 1
-		initdcheck || return 1
-	fi
+	verify || return 1
+	initdcheck || return 1
 	mkdir -p "$srcdir"
 	for u in $source; do
 		local s
@@ -2405,7 +2403,7 @@ usage() {
 		 -c  Enable colored output
 		 -d  Disable dependency checking
 		 -D  Set APKINDEX description (default: \$repo \$(git describe))
-		 -f  Force specified cmd, even if they are already done
+		 -f  Force specified cmd (skip checks: apk up to date, arch, libc)
 		 -F  Force run as root
 		 -h  Show this help
 		 -i  Install PKG after successful build


### PR DESCRIPTION
The force flag used to skip the following functions, without any
documentation in the help (-h) output:
* verify (checksum verification)
* initdcheck (check if the init scripts are openrc scripts)
* check_arch (check if the target architecture is in "arch=")
* check_libc (check if the target libc is masked in the options)

This was counter-intuitive and could even be dangerous (when one relies
on the checksum verification to prevent man-in-the-middle attacks, but
always uses the -f flag).

---

Notably this did not skip all checks in `abuild.in` anyway (search for `check_` in the file).
As previously discussed here: https://lists.alpinelinux.org/alpine-devel/5962.html
Closes https://bugs.alpinelinux.org/issues/8257
Closes postmarketOS/pmbootstrap#1185