### PR TITLE
Don't print 'git: not found' errors

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -12,6 +12,7 @@ sysconfdir=@sysconfdir@
 datadir=@datadir@
 
 abuild_path=$(readlink -f $0)
+git_path=$(command -v git || true)
 
 if ! [ -f "$datadir/functions.sh" ]; then
 	echo "$datadir/functions.sh: not found" >&2
@@ -797,13 +798,13 @@ prepare_language_packs() {
 
 # echo '-dirty' if git is not clean
 git_dirty() {
-	if [ $(git status -s "$startdir" | wc -l) -ne 0 ]; then
-		echo "-dirty"
-	fi
+	[ -z "$git_path" ] && return
+	[ $(git status -s "$startdir" | wc -l) -ne 0 ] && echo "-dirty"
 }
 
 # echo last commit hash id
 git_last_commit() {
+	[ -z "$git_path" ] && return
 	git log --format=oneline -n 1 "$startdir" | awk '{print $1}'
 }
 
@@ -1511,7 +1512,14 @@ update_abuildrepo_index() {
 	done
 	subpkg_unset
 
-	[ -z "$DESCRIPTION" ] && DESCRIPTION="$repo $(cd $startdir && git describe || true)"
+	if [ -z "$DESCRIPTION" ]; then
+		if [ -n "$git_path" ]; then
+			DESCRIPTION="$repo $(cd $startdir && git describe)"
+		else
+			DESCRIPTION="$repo"
+		fi
+	fi
+
 	for i in $allarch; do
 		cd "$REPODEST/$repo/$i"
 		local index=$i/APKINDEX.tar.gz
@@ -2359,8 +2367,7 @@ snapshot() {
 	# clone git repo and archive
 	if [ -n "$giturl" ]; then
 		local _version=${verbase:-0}_git${_date}
-		command -v git >/dev/null || \
-			die "Missing git! Install git to support git clone."
+		[ -z "$git_path" ] &&  die "Missing git! Install git to support git clone."
 		local _rev="${reporev:-HEAD}"
 		[ "$_rev" = "HEAD" ] && local _depth="--depth=1"
 		msg "Creating git snapshot: $pkgname-$_version"


### PR DESCRIPTION
abuild, as packaged in Alpine Linux, does not depend on git. But when
you use it without git, it will print out errors like the following:

> /usr/bin/abuild: line 2554: git: not found

With this commit, it saves the git_path in the beginning (just like
abuild_path). Later in the code it does not try to run git if that
variable is empty.

Notably `abuild rootbld` is already checking whether `abuild-rootbld`
is installed, and that subpackage of `abuild` does already depend on
`git`. So no additional check was added before using `git ` inside
`rootbld`.

Fixes https://github.com/postmarketOS/pmbootstrap/issues/1209.