### PR TITLE
newapkbuild: check arguments and improve usage()

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -158,7 +158,7 @@ newaport() {
 		pkgname=$pn
 	fi
 	if [ -e "$pkgname"/APKBUILD ] && [ -z "$force" ]; then
-		error "$pkgname/APKBUILD already exist"
+		error "$pkgname/APKBUILD already exists"
 		return 1
 	fi
 	mkdir -p "$pkgname"
@@ -315,13 +315,14 @@ __EOF__
 usage() {
 	cat >&2 <<-__EOF__
 		$program $program_version - generate a new APKBUILD
-		Usage: $program [-n NAME] [-d DESC] [-l LICENSE] [-u URL]
-		       [-aCpy] [-s] [-cfh]
-		       PKGNAME[-PKGVER]|SRCURL
+		Usage: $program [-n PKGNAME] [-d PKGDESC] [-l LICENSE] [-u URL]
+		       [-a | -C | -m | -p | -y] [-s] [-c] [-f] [-h]
+		       PKGNAME[-PKGVER] | SRCURL
 		Options:
-		  -n  Set package name to NAME
-		  -d  Set package description (pkgdesc) to DESC
-		  -l  Set package license to LICENSE
+		  -n  Set package name to PKGNAME (only use with SRCURL)
+		  -d  Set package description to PKGDESC
+		  -l  Set package license to LICENSE, use identifiers from:
+		      <https://spdx.org/licenses/>
 		  -u  Set package URL
 		  -a  Create autotools package (use ./configure ...)
 		  -C  Create CMake package (Assume cmake/ is there)
@@ -329,33 +330,58 @@ usage() {
 		  -p  Create perl package (Assume Makefile.PL is there)
 		  -y  Create python package (Assume setup.py is there)
 		  -s  Use sourceforge source URL
-		  -c  Copy a sample init.d, conf.d, and install script to new directory
-		  -f  Force even if directory already exist
+		  -c  Copy a sample init.d, conf.d, and install script
+		  -f  Force even if directory already exists
 		  -h  Show this help
-
 	__EOF__
+}
+
+set_buildtype() {
+	if [ -n "$buildtype" ]; then
+		error "More than one buildtype flag specified ($buildtype and $1)"
+		exit 1
+	fi
+	buildtype="$1"
+}
+
+check_arguments() {
+	if [ $# -eq 0 ]; then
+		error "Missing required argument: PKGNAME[-PKGVER] | SRCURL"
+		exit 1
+	fi
+	if [ $# -gt 1 ]; then
+		shift
+		error "Unrecognized arguments: $*"
+		exit 1
+	fi
+	if ! is_url "$1" && [ -n "$pkgname" ]; then
+		error "-n is only allowed when using SRCURL as last argument"
+		exit 1
+	fi
+	if is_url "$1" && [ -n "$sourceforge" ]; then
+		error "-s is only allowed when using PKGNAME as last argument"
+		exit 1
+	fi
 }
 
 while getopts "acCmd:fhl:n:pyu:s" opt; do
 	case $opt in
-		'a') buildtype="autotools";;
+		'a') set_buildtype "autotools";;
 		'c') cpinitd=1;;
-		'C') buildtype="cmake";;
-		'm') buildtype="meson";;
+		'C') set_buildtype "cmake";;
+		'm') set_buildtype "meson";;
 		'd') pkgdesc="$OPTARG";;
 		'f') force=1;;
 		'h') usage; exit;;
 		'l') license="$OPTARG";;
 		'n') pkgname="$OPTARG";;
-		'p') buildtype="perl";;
-		'y') buildtype="python";;
+		'p') set_buildtype "perl";;
+		'y') set_buildtype "python";;
 		'u') url="$OPTARG";;
 		's') sourceforge=1;;
 	esac
 done
 shift $(( $OPTIND - 1 ))
 
-while [ $# -gt 0 ]; do
-	newaport $1 || exit 1
-	shift
-done
+check_arguments "$@"
+newaport $1


### PR DESCRIPTION
### Changes
* argument sanity checks:
  * `PKGNAME[-PKGVER] | SRCURL`
    * check if missing
    * check if specified more than once (see below)
  * specifying more than one buildtype flag
  * `-n` (set pkgname) without using SRCURL as last argument
  * `-s` (sourceforge source) without using PKGNAME as last argument
* Typo fix: exist -> exists
* `usage()`:
  * always print PKGNAME and PKGDESC (instead of NAME and DESC,
    NAME was used in one place and PKGNAME in another)
  * link to <https://spdx.org/licenses/>
  * `-m` (meson) flag was missing in short usage line at the top
  * indicate that the buildtypes are exclusive
  * `-c` flag: remove "to new directory" wording to make the
    message shorter (this should be obvious)
  * remove empty line at the end

NOTE: Before this commit, the `PKGNAME[-PKGVER] | SRCURL` was allowed
to be specified more than once, and the code looped over the arguments.
But this was not documented in `usage()` and had unexpected results:

```
$ newapkbuild first second third
$ tree
.
___ first
    ___ APKBUILD
    ___ first
    ___ ___ APKBUILD
    ___ ___ first
    ___ ___ ___ APKBUILD
    ___ ___ ___ src
    ___ ___ src
    ___ src
```

### Examples
```
$ newapkbuild -C -m test
>>> ERROR: More than one buildtype flag specified (cmake and meson)
```

```
$ newapkbuild
>>> ERROR: Missing required argument: PKGNAME[-PKGVER] | SRCURL
```

```
$ newapkbuild first second third
>>> ERROR: Unrecognized arguments: second third
```

```
$ newapkbuild test -C -f
>>> ERROR: Unrecognized arguments: -C -f
```

```
$ newapkbuild -n mypkgname mypkgname
>>> ERROR: -n is only allowed when using SRCURL as last argument
```

```
$ newapkbuild -s "https://github.com/alpinelinux/abuild/archive/v3.1.0.tar.gz"
>>> ERROR: -s is only allowed when using PKGNAME as last argument
```

### Old usage
```
newapkbuild 3.1.0-14-g54dbf5f - generate a new APKBUILD
Usage: newapkbuild [-n NAME] [-d DESC] [-l LICENSE] [-u URL]
       [-aCpy] [-s] [-cfh]
       PKGNAME[-PKGVER]|SRCURL
Options:
  -n  Set package name to NAME
  -d  Set package description (pkgdesc) to DESC
  -l  Set package license to LICENSE
  -u  Set package URL
  -a  Create autotools package (use ./configure ...)
  -C  Create CMake package (Assume cmake/ is there)
  -m  Create meson package (Assume meson.build is there)
  -p  Create perl package (Assume Makefile.PL is there)
  -y  Create python package (Assume setup.py is there)
  -s  Use sourceforge source URL
  -c  Copy a sample init.d, conf.d, and install script to new directory
  -f  Force even if directory already exist
  -h  Show this help

```

### New usage
```
newapkbuild 3.1.0-.... - generate a new APKBUILD
Usage: newapkbuild [-n PKGNAME] [-d PKGDESC] [-l LICENSE] [-u URL]
       [-a | -C | -m | -p | -y] [-s] [-c] [-f] [-h]
       PKGNAME[-PKGVER] | SRCURL
Options:
  -n  Set package name to PKGNAME (only use with SRCURL)
  -d  Set package description to PKGDESC
  -l  Set package license to LICENSE, use identifiers from:
      <https://spdx.org/licenses/>
  -u  Set package URL
  -a  Create autotools package (use ./configure ...)
  -C  Create CMake package (Assume cmake/ is there)
  -m  Create meson package (Assume meson.build is there)
  -p  Create perl package (Assume Makefile.PL is there)
  -y  Create python package (Assume setup.py is there)
  -s  Use sourceforge source URL
  -c  Copy a sample init.d, conf.d, and install script
  -f  Force even if directory already exists
  -h  Show this help
```