### PR TITLE
abuild: check license for valid SPDX license identifiers

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -233,6 +233,7 @@ default_sanitycheck() {
 	[ -n "$checkdepend" ] && spell_error checkdepend checkdepends
 
 	check_maintainer || die "Provide a valid RFC822 maintainer address"
+	check_license || warning "Please use valid SPDX license identifiers found at: https://spdx.org/licenses"
 
 	check_depends_dev || warning "depends_dev found but no development subpackage found"
 	check_secfixes_comment || return 1
@@ -835,6 +836,21 @@ check_maintainer() {
 			*) return 1 ;;
 		esac
 	fi
+}
+
+check_license() {
+	local ret=0
+	local license_list=/usr/share/spdx/license.lst
+	if options_has "!spdx" || ! [ -f "$license_list" ]; then
+		return 0
+	fi
+	local i; for i in $license; do
+		if ! grep -q -w -F "$i" "$license_list"; then
+			ret=1
+			warning "\"$i\" is not a known license"
+		fi
+	done
+	return $ret
 }
 
 check_secfixes_comment() {


### PR DESCRIPTION
licenses will be checked against the license.lst file provided by
the spdx-licenses-list package when installed except when explicitly
disabled by the !spdx options flag.