### PR TITLE
Clarify abuild commands in usage()

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -2456,7 +2456,7 @@ usage() {
 		  fetch       Fetch sources to \$SRCDEST and verify checksums
 		  index       Regenerate indexes in \$REPODEST
 		  listpkg     List target packages
-		  package     Create package in \$REPODEST
+		  package     Install project into $pkgdir
 		  prepare     Apply patches
 		  rootbld     Build package in clean chroot
 		  rootpkg     Run 'package', the split functions and create apks as fakeroot


### PR DESCRIPTION
abuild package misleadingly states that it will create packages in $REPODIR (suggesting that it actually creates apks).
The documentation in the wiki is more correct, this fix makes it consistent with the wiki.