### PR TITLE
Fix: incomplete partfile gets renamed to distfile

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -332,9 +332,20 @@ sourcecheck() {
 
 uri_fetch() {
 	local uri="$1"
+	local status=0
 	mkdir -p "$SRCDEST"
 	msg "Fetching $uri"
-	abuild-fetch -d "$SRCDEST" "$uri"
+	abuild-fetch -d "$SRCDEST" "$uri" || status=$?
+
+	# try again when server does not support resume
+	if [ "$status" -eq 33 ] && command -v curl > /dev/null; then
+		local partfile="$SRCDEST/$(filename_from_uri $uri).part"
+		msg "Removing partial download and trying again: $partfile"
+		rm "$partfile"
+		uri_fetch "$uri"
+	else
+		return $status
+	fi
 }
 
 is_remote() {


### PR DESCRIPTION
### Overview
Abuild-fetch uses curl (fallback to wget) to download files. They are
saved with a ".part" extension first, so they can be resumed if
necessary. When the download is through, the ".part" extension gets
removed. However, when the server does not support resume of downloads
(e.g. GitHub's on the fly generated tarballs), then the ".part"
extension got removed anyway. Abuild aborts in that case. But when
running a third time, the distfile exists and it is assumed that this
is the full download.

### Changes
* abuild-fetch:
  * Only remove the ".part" extension, when curl/wget exit with 0
  * Pass the exit code from curl/wget as exit code of abuild-fetch
  * Wherever abuild-fetch would return an exit code on its own, the
    codes have been changed to be > 200 (so they don't collide with
    curl's as of now 92 exit codes)
  * Remove undocumented feature of downloading multiple source URLs at
    a time. This doesn't match with the usage description, was not used
    in abuild at all and it would have made it impossible to pass the
    exit code.
* abuild:
  * After downloading, when curl is installed and abuild-fetch has
    33 as exit code (curl's HTTP range error), then delete the partfile
    and try the download again.

### How to test
* Create a new APKBUILD
* Add a [large on the fly generated GitHub tarball](https://github.com/torvalds/linux/archive/0adb32858b0bddf4ada5f364a84ed60b196dbcda.tar.gz) to the sources
* Run `abuild checksum` and abort the download after it started with ^C
* Run `abuild checksum` again
  * With the patch it will delete the temporary file and retry
  * Without the patch, it will exit with an error and rename the partfile to 
    the distfile (running `abuild checksum` a third time makes it checksum 
    the partial file!)

Fixes https://github.com/postmarketOS/pmbootstrap/issues/1407

**NOTE:** `newapkbuild` has a similar undocumented feature of accepting an 
unlimited amount of arguments, which would be fixed with PR #34.