### PR TITLE
Fix newapkbuild

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -228,7 +228,7 @@ subpackages="\$pkgname-dev \$pkgname-doc"
 source="$source"
 __EOF__
 
-	abuild -f fetch unpack
+	abuild -f fetch checksum unpack
 	# Figure out the builddir
 	for i in src/*; do
 		if [ -d "$i" ]; then
@@ -339,7 +339,6 @@ __EOF__
 }
 
 __EOF__
-	abuild -f checksum
 }
 
 usage() {

--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -170,7 +170,7 @@ newaport() {
 		pkgname=$pn
 	fi
 	if [ -e "$pkgname"/APKBUILD ] && [ -z "$force" ]; then
-		error "$pkgname/APKBUILD already exist"
+		error "$pkgname/APKBUILD already exists"
 		return 1
 	fi
 	mkdir -p "$pkgname"


### PR DESCRIPTION
* Minor typo in error message if an APKBUILD already exists

* 6981f3a6 broke `newapkbuild` because it does not run checksum before unpack.  This fixes that issue, so that `newapkbuild` works as expected again.