### PR TITLE
checkapk: remove temporary dir on SIGINT and exit

### DIFF
--- a/checkapk.in
+++ b/checkapk.in
@@ -47,6 +47,7 @@ fi
 
 startdir="$PWD"
 tmpdir=$(mktemp -d -t checkpkg-script.XXXXXX)
+trap "rm -rf '$tmpdir'" INT EXIT
 cd "$tmpdir" || die "failed to create temp dir"
 
 for i in $pkgname $subpackages; do
@@ -91,5 +92,3 @@ for i in $pkgname $subpackages; do
 		msg "No soname differences for $_pkgname."
 	fi
 done
-
-msg "Files saved to $tmpdir"


### PR DESCRIPTION
Is there any specific reason why `checkapk` retains `$tmpdir`? I personally find it very annoying to occasionally go trough `/tmp` and delete all `/tmp/checkapk*` files manually.

If there is a specific reason for retaining this behavior it shouldn't be the default behavior, instead a flag should be provided. If there isn't this PR should be merged as is.