### PR TITLE
abuild.in: add multithreaded compression

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1451,6 +1451,7 @@ human_size() {
 
 create_apks() {
 	local file= dir= name= ver= apk= datadir= size=
+	local gzip=$(command -v pigz || echo gzip)
 	getpkgver || return 1
 	if ! options_has "!tracedeps"; then
 		for file in "$pkgbasedir"/.control.*/.PKGINFO; do
@@ -1487,7 +1488,7 @@ create_apks() {
 			touch .dummy
 			set -- .dummy
 		fi
-		tar --xattrs -f - -c "$@" | abuild-tar --hash | gzip -9 >"$dir"/data.tar.gz
+		tar --xattrs -f - -c "$@" | abuild-tar --hash | $gzip -9 >"$dir"/data.tar.gz
 
 		msg "Create checksum..."
 		# append the hash for data.tar.gz


### PR DESCRIPTION
The `Compressing data` step takes a significant amount of time when
packaging software with huge binaries, like Kubernetes. This can
certainly be shortened using multithreaded compression, like `pigz`.

This PR is inspired by [a similar patch in Adelie Linux][1], but I'm not sure how
it works in there. `command -v` only checks for multiple arguments in `bash`,
not `ash`.

[1]: https://code.foxkit.us/adelie/packages/blob/master/system/abuild/use-pigz.patch