### PR TITLE
abuild: perform stricter file name checks for $source

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -201,14 +201,16 @@ default_sanitycheck() {
 			list_has ${i##*/} $md5sums $sha256sums $sha512sums \
 				|| die "${i##*/} is missing in checksums"
 
-			# verify that our source does not have git tag version
-			# name as tarball (typicallly github)
-			if is_remote "$i" && [ "${i#*::}" = "$i" ]; then
-				case ${i##*/} in
-				v$pkgver.tar.*|$pkgver.tar.*)
-					die "source ${i##*/} needs to be renamed to avoid possible collisions"
-					;;
-				esac
+			is_remote "$i" || continue
+			local fn="$(filename_from_uri "$i")"
+
+			# Check that file name contains at least the package
+			# name and package version. Otherwise it is not
+			# guaranteed to be unique.
+			if [ "${fn##$pkgname}" = "$fn" ]; then
+				die "source ${i##*/} file name doesn't contain \$pkgname"
+			elif [ "${fn##$pkgver}" = "$fn" ]; then
+				die "source ${i##*/} file name doesn't contain \$pkgver"
 			fi
 		done
 	fi


### PR DESCRIPTION
abuild: perform stricter file name checks for $source

The current version didn't detect many cases where the file name was not
sufficient. For example the following wasn't detected:

    source="https://github.com/stedolan/jq/archive/${_pkgver}.tar.gz"

This commit attempts to fix this by making sure that the file name
contains at least the `$pkgname` and the `$pkgver`.

Even stricter checks, e.g. check  for `$pkgname-$pkgver.*`, are not
possible since they wouldn't allow multiple sources.