### PR TITLE
Update apkbuild for metacpan

### DIFF
--- a/apkbuild-cpan.in
+++ b/apkbuild-cpan.in
@@ -110,7 +110,7 @@ sub read_apkbuild {
 sub write_apkbuild {
 	my ($distdata, $authors, $moddata) = @_;
 
-	my $cpanid = $distdata->{releases}[0]->{id};
+	my $cpanid = $distdata->{id};
 	$cpanid = substr($cpanid, 0, 1) . "/" . substr($cpanid, 0, 2) . "/$cpanid";
 
 	my %repl = (
@@ -323,7 +323,12 @@ sub get_data {
 	my $distdata = $json->decode($response->decoded_content);
 	$distdata->{error} and die "Error trying to locate $apkbuild->{_pkgreal}: $distdata->{error}\n";
 
-	return ($apkbuild, $distdata);
+	$response = $ua->get("https://fastapi.metacpan.org/module/$distdata->{main_module}");
+	$response->is_success or die $response->status_line;
+	my $moddata = $json->decode($response->decoded_content);
+	$moddata->{error} and die "Error trying to locate $distdata->{main_module}: $moddata->{error}\n";
+
+	return ($apkbuild, $distdata, $moddata);
 }
 
 my $abuild_conf = read_assignments_from_file("/etc/abuild.conf");
@@ -357,14 +362,14 @@ given ( $ARGV[0] ) {
 		do_depends;
 	}
 	when ("recreate") {
-		my ($apkbuild, $distdata) = get_data;
-		write_apkbuild($distdata, $apkbuild->{authors});
+		my ($apkbuild, $distdata, $moddata) = get_data;
+		write_apkbuild($distdata, $apkbuild->{authors}, $moddata);
 		prepare_tree;
 		update_functions;
 		do_depends;
 	}
 	when ("upgrade") {
-		my ($apkbuild, $distdata) = get_data;
+		my ($apkbuild, $distdata, $moddata) = get_data;
 
 		my $pkgver = $distdata->{metadata}{version};
 		if ($pkgver != $apkbuild->{pkgver}) {
@@ -385,8 +390,8 @@ given ( $ARGV[0] ) {
 		}
 	}
 	when ('check') {
-		my ($apkbuild, $distdata) = get_data;
-		my $pkgver = $distdata->{releases}[0]->{version};
+		my ($apkbuild, $distdata, $moddata) = get_data;
+		my $pkgver = $distdata->{metadata}{version};
 		say "$apkbuild->{pkgname}: Latest version: $pkgver Packaged version: $apkbuild->{pkgver}";
 		if ($pkgver ne $apkbuild->{pkgver}) {
 			exit(1);

--- a/apkbuild-cpan.in
+++ b/apkbuild-cpan.in
@@ -371,7 +371,7 @@ given ( $ARGV[0] ) {
 	when ("upgrade") {
 		my ($apkbuild, $distdata, $moddata) = get_data;
 
-		my $pkgver = $distdata->{metadata}{version};
+		my $pkgver = $moddata->{version};
 		if ($pkgver != $apkbuild->{pkgver}) {
 			say "Upgrading CPAN module from $apkbuild->{pkgver} to $pkgver";
 
@@ -391,7 +391,7 @@ given ( $ARGV[0] ) {
 	}
 	when ('check') {
 		my ($apkbuild, $distdata, $moddata) = get_data;
-		my $pkgver = $distdata->{metadata}{version};
+		my $pkgver = $moddata->{version};
 		say "$apkbuild->{pkgname}: Latest version: $pkgver Packaged version: $apkbuild->{pkgver}";
 		if ($pkgver ne $apkbuild->{pkgver}) {
 			exit(1);

--- a/apkbuild-cpan.in
+++ b/apkbuild-cpan.in
@@ -31,7 +31,7 @@ _pkgreal=[% pkgreal %]
 pkgver=[% pkgver %]
 pkgrel=0
 pkgdesc="Perl module for [% pkgreal %]"
-url="http://search.cpan.org/dist/[% pkgreal %]/"
+url="https://metacpan.org/release/[% pkgreal %]/"
 arch="noarch"
 license="GPL PerlArtistic"
 cpandepends=""
@@ -110,15 +110,15 @@ sub read_apkbuild {
 sub write_apkbuild {
 	my ($distdata, $authors) = @_;
 
-	my $cpanid = $distdata->{releases}[0]->{cpanid};
+	my $cpanid = $distdata->{releases}[0]->{id};
 	$cpanid = substr($cpanid, 0, 1) . "/" . substr($cpanid, 0, 2) . "/$cpanid";
 
 	my %repl = (
 		authors  => ($authors or "# Contributor: $packager\n# Maintainer: $packager"),
-		pkgname  => map_cpan_to_apk($distdata->{name}),
-		pkgreal  => $distdata->{name},
-		pkgver   => $distdata->{releases}[0]->{version},
-		source   => "http://search.cpan.org/CPAN/authors/id/$cpanid/\$_pkgreal-\$pkgver.tar.gz",
+		pkgname  => map_cpan_to_apk($distdata->{metadata}{name}),
+		pkgreal  => $distdata->{metadata}{name},
+		pkgver   => $distdata->{version},
+		source   => $distdata->{download_url},
 	);
 	$template =~ s/\[% (.*?) %\]/$repl{$1}/g;
 
@@ -143,16 +143,16 @@ sub parse_deps {
 		next if $module eq 'perl';
 
 		# map module name to package name
-		$response = $ua->get("http://search.cpan.org/api/module/$module");
+		$response = $ua->get("https://fastapi.metacpan.org/module/$module");
 		$response->is_success or die $response->status_line;
 		my $moddata = $json->decode($response->decoded_content);
 		$moddata->{error} and die "Error trying to locate $module: $moddata->{error}\n";
-		$distfiles->{$moddata->{distvname}} = $moddata;
+		$distfiles->{$moddata->{distribution}} = $moddata;
 	}
 
 	# map package names to alpine packages
 	foreach ( keys %{ $distfiles } ) {
-		$response = $ua->get("http://search.cpan.org/api/dist/$_");
+		$response = $ua->get("https://fastapi.metacpan.org/releases/$_");
 		$response->is_success or die $response->status_line;
 		my $distdata = $json->decode($response->decoded_content);
 		$distdata->{error} and die "Error trying to locate $_: $distdata->{error}\n";
@@ -317,7 +317,7 @@ sub do_depends {
 sub get_data {
 	my $apkbuild = read_apkbuild;
 	$apkbuild->{_pkgreal} or die "Not apkbuild-cpan generated APKBUILD";
-	my $response = $ua->get("http://search.cpan.org/api/dist/$apkbuild->{_pkgreal}");
+	my $response = $ua->get("https://fastapi.metacpan.org/release/$apkbuild->{_pkgreal}");
 	$response->is_success or die $response->status_line;
 	my $distdata = $json->decode($response->decoded_content);
 	$distdata->{error} and die "Error trying to locate $apkbuild->{_pkgreal}: $distdata->{error}\n";
@@ -337,17 +337,17 @@ given ( $ARGV[0] ) {
 		my $response;
 		$module or die "Module name is a mandatory argument";
 
-		$response = $ua->get("http://search.cpan.org/api/module/$module");
+		$response = $ua->get("https://fastapi.metacpan.org/module/$module");
 		$response->is_success or die $response->status_line;
 		my $moddata = $json->decode($response->decoded_content);
 		$moddata->{error} and die "Error trying to locate $module: $moddata->{error}\n";
 
-		$response = $ua->get("http://search.cpan.org/api/dist/$moddata->{distvname}");
+		$response = $ua->get("https://fastapi.metacpan.org/release/$moddata->{distribution}");
 		$response->is_success or die $response->status_line;
 		my $distdata = $json->decode($response->decoded_content);
 		$distdata->{error} and die "Error trying to locate $module: $distdata->{error}\n";
 
-		my $apkname = map_cpan_to_apk $distdata->{name};
+		my $apkname = map_cpan_to_apk $distdata->{metadata}{name};
 		mkdir $apkname;
 		chdir $apkname;
 		write_apkbuild($distdata);

--- a/apkbuild-cpan.in
+++ b/apkbuild-cpan.in
@@ -117,7 +117,7 @@ sub write_apkbuild {
 		authors  => ($authors or "# Contributor: $packager\n# Maintainer: $packager"),
 		pkgname  => map_cpan_to_apk($distdata->{metadata}{name}),
 		pkgreal  => $distdata->{metadata}{name},
-		pkgver   => $distdata->{version},
+		pkgver   => $distdata->{metadata}{version},
 		source   => $distdata->{download_url},
 	);
 	$template =~ s/\[% (.*?) %\]/$repl{$1}/g;
@@ -365,7 +365,7 @@ given ( $ARGV[0] ) {
 	when ("upgrade") {
 		my ($apkbuild, $distdata) = get_data;
 
-		my $pkgver = $distdata->{releases}[0]->{version};
+		my $pkgver = $distdata->{metadata}{version};
 		if ($pkgver != $apkbuild->{pkgver}) {
 			say "Upgrading CPAN module from $apkbuild->{pkgver} to $pkgver";
 

--- a/apkbuild-cpan.in
+++ b/apkbuild-cpan.in
@@ -108,17 +108,17 @@ sub read_apkbuild {
 }
 
 sub write_apkbuild {
-	my ($distdata, $authors) = @_;
+	my ($distdata, $authors, $moddata) = @_;
 
 	my $cpanid = $distdata->{releases}[0]->{id};
 	$cpanid = substr($cpanid, 0, 1) . "/" . substr($cpanid, 0, 2) . "/$cpanid";
 
 	my %repl = (
 		authors  => ($authors or "# Contributor: $packager\n# Maintainer: $packager"),
-		pkgname  => map_cpan_to_apk($distdata->{metadata}{name}),
-		pkgreal  => $distdata->{metadata}{name},
-		pkgver   => $distdata->{metadata}{version},
-		source   => $distdata->{download_url},
+		pkgname  => map_cpan_to_apk($moddata->{distribution}),
+	 	pkgreal  => $moddata->{distribution},
+	 	pkgver  => $moddata->{version},
+		source   => $moddata->{download_url},
 	);
 	$template =~ s/\[% (.*?) %\]/$repl{$1}/g;
 
@@ -152,7 +152,7 @@ sub parse_deps {
 
 	# map package names to alpine packages
 	foreach ( keys %{ $distfiles } ) {
-		$response = $ua->get("https://fastapi.metacpan.org/releases/$_");
+		$response = $ua->get("https://fastapi.metacpan.org/release/$_");
 		$response->is_success or die $response->status_line;
 		my $distdata = $json->decode($response->decoded_content);
 		$distdata->{error} and die "Error trying to locate $_: $distdata->{error}\n";
@@ -258,6 +258,7 @@ EOF
 }
 
 sub do_depends {
+
 	my $apkbuild = read_apkbuild;
 	my $metaprefix = "src/" . $apkbuild->{'_pkgreal'} . "-" . $apkbuild->{'pkgver'} . "/";
 	my $meta;
@@ -350,7 +351,7 @@ given ( $ARGV[0] ) {
 		my $apkname = map_cpan_to_apk $distdata->{metadata}{name};
 		mkdir $apkname;
 		chdir $apkname;
-		write_apkbuild($distdata);
+		write_apkbuild($distdata, undef, $moddata);
 		prepare_tree;
 		update_functions;
 		do_depends;


### PR DESCRIPTION
search.cpan.org has been discontinued and redirects to metacpan 

https://www.perl.com/article/saying-goodbye-to-search-cpan-org/  

This fixes the code for apkbuild-cpan and it appears to create valid APKBUILD files

It is possible that the values I chose are incorrect based on the metadata that fastapi.metacpan.org returns.  I made no attempt to change the functionality, simply find what would appear to be equivalent values. 