### PR TITLE
abuild-sign: actually catch errors while signing

### DIFF
--- a/abuild-sign.in
+++ b/abuild-sign.in
@@ -26,7 +26,7 @@ do_sign() {
 		i=$(readlink -f $f)
 		[ -d "$i" ] && i="$i/APKINDEX.tar.gz"
 		repo="${i%/*}"
-		(
+		trap 'die "failed to sign $i"' EXIT
 		set -e
 		cd "$repo"
 		sig=".SIGN.RSA.$keyname"
@@ -39,7 +39,8 @@ do_sign() {
 		chmod 644 "$tmpsigned"
 		mv "$tmpsigned" "$i"
 		msg "Signed $i"
-		) || die "failed to sign $i"
+		set +e
+		trap - EXIT
 	done
 }
 


### PR DESCRIPTION
`set -e` actually does not work as intended if used in a subshell (in various shells, including `ash`/`dash`), see e.g. [1] for details.

I hit into this while experimenting with `abuild-sign` and passphrase-protected private keys.

[1] https://unix.stackexchange.com/questions/296526/set-e-in-a-subshell