### PR TITLE
abuild: replace command -v with which to fix build issues

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1597,7 +1597,7 @@ check() {
 
 # predefined splitfunc doc
 default_doc() {
-	local gzip=$(command -v pigz || echo gzip)
+	local gzip=$(which pigz || echo gzip)
 	depends="$depends_doc"
 	pkgdesc="$pkgdesc (documentation)"
 	install_if="docs $pkgname=$pkgver-r$pkgrel"


### PR DESCRIPTION
When building alpine community/abiword package, in abuild's default_doc() function the statement: 
local gzip=$(command -v pigz || echo gzip)
fails because the built-in 'command -v pigz' is failing (whether the pigz apk is installed or not.) The result of the failure is that gzip is assigned a null value. Later when $gzip is used to compress the doc files an error is generated:
>>> abiword-doc*: Running split function doc...
/usr/bin/abuild: line 1643: -9: not found
>>> ERROR: abiword-doc*: doc failed

Note: line 1643: [ $islink -eq 0 ] && $gzip -9 "$name"

I'm unsure why 'command -v' is failing (maybe the presence of ./pkg/abiword-doc/usr/lib/abiword-3.0/plugins/command.so)

Using the 'which' command (busybox) would avoid the error and should always be present.   

Alternatively the relevant portion of commit https://github.com/alpinelinux/abuild/commit/909623950f17989ad145c6162ce62ee64701f0fc#diff-88af1a35b35ecf6afcb7687f5afc7bbc could be reverted.