### PR TITLE
abuild-clean: add option to make files writable before cleanup

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -77,6 +77,10 @@ want_check() {
 }
 
 default_cleanup_srcdir() {
+	if option_has options_has "chmod-clean" && test -d "$srcdir"
+	then
+		chmod -R +w "$srcdir"
+	fi
 	rm -rf "$srcdir"
 }
 


### PR DESCRIPTION
Some projects might leave files which are not writable for the current
user. The cleanup process then fails and leaves files / directories
behind.

This can easily be fixed by making everything writable before removing
the files.

Add the option 'chmod-clean' which does just that.