### PR TITLE
get and use pkgdesc from cpan api data if the module has no metadata …

### DIFF
--- a/apkbuild-cpan.in
+++ b/apkbuild-cpan.in
@@ -108,6 +108,7 @@ sub write_apkbuild {
 		pkgreal  => $moddata->{distribution},
 		pkgver  => $moddata->{version},
 		source   => $moddata->{download_url} =~ s/$moddata->{version}/\$pkgver/r,
+		pkgdesc  => $distdata->{abstract},
 	);
 	$template =~ s/\[% (.*?) %\]/$repl{$1}/g;
 
@@ -262,7 +263,7 @@ sub do_depends {
 	say "CPAN check deps: $makedeps";
 
 	my $text = read_file "APKBUILD";
-	if ($abstract) {
+	if ($abstract && $abstract ne 'unknown') {
 		$text =~ s/^pkgdesc=\"([^\"]*)\"$/pkgdesc=\"$abstract\"/mg or
 			die "Can't find cpandepends line in APKBUILD";
 	}


### PR DESCRIPTION
…files (returns unknown)

Simply uses the results from the metacpan api if the alternative is unknown