### PR TITLE
functions: adjust armhf triplet

### DIFF
--- a/functions.sh.in
+++ b/functions.sh.in
@@ -7,7 +7,7 @@ arch_to_hostspec() {
 	case "$1" in
 	aarch64)	echo "aarch64-alpine-linux-musl" ;;
 	armel)		echo "armv5-alpine-linux-musleabi" ;;
-	armhf)		echo "armv6-alpine-linux-muslgnueabihf" ;;
+	armhf)		echo "armv6-alpine-linux-musleabihf" ;;
 	armv7)		echo "armv7-alpine-linux-musleabihf" ;;
 	mips)           echo "mips-alpine-linux-musl" ;;
 	mips64)         echo "mips64-alpine-linux-musl" ;;


### PR DESCRIPTION
From what I could find, it was changed to -musleabihf during the Alpine 3.6 release cycle but this function was never updated to reflect that