### PR TITLE
Verify GPG signatures before checksum

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -312,6 +312,14 @@ gpg_verify() {
 		[ -n "$(command -v gpg2)" ] && \
 		gpg2 --version >/dev/null
 	then
+		if [ -s "${startdir}/GPGKEYS" ]; then
+			gpg2 --homedir "${srcdir}/.gnupg" --quiet \
+				--keyid-format 0xlong \
+				--auto-key-retrieve \
+				--trust-model tofu+pgp \
+				--import "${startdir}/GPGKEYS"
+		fi
+
 		local trust fingerprint
 		echo "$gpgfingerprints" | tr ',' '\n' | while IFS=: read -r trust fingerprint; do
 			case "$(printf -- '%s' $trust)" in

--- a/abuild.in
+++ b/abuild.in
@@ -363,7 +363,7 @@ gpg_verify() {
 		allverified=true
 
 		local uri filename srcpath gpgverified
-		for uri in $source; do
+		for uri in ${gpgsource:-$source}; do
 			filename="$(filename_from_uri "$uri")"
 			[ "$filename" != "${pkgname}-GPGKEYS" ] || continue
 			srcpath="${srcdir}/${filename}"
@@ -512,6 +512,7 @@ fetch_gpg_signatures() {
 	url="$(url_from_uri "$uri")"
 	filename="$(filename_from_uri "$uri")"
 	[ "$filename" != "${pkgname}-GPGKEYS" ] || return 0
+	list_has "$uri" ${gpgsource:-$source} || return 0
 
 	fetched=false
 	for sigext in $gpg_signature_extensions; do
@@ -520,7 +521,9 @@ fetch_gpg_signatures() {
 	done
 
 	if ! $fetched; then
-		warning "Could not fetch any GPG signatures"
+		error "Could not fetch any GPG signatures for ${filename}"
+		error2 "Try adjusting gpg_signature_extensions variable in APKBUILD"
+		error2 "Remove the URI from gpgsource if there is no GPG signature"
 		return 1
 	fi
 

--- a/abuild.in
+++ b/abuild.in
@@ -312,13 +312,17 @@ gpg_verify() {
 		[ -n "$(command -v gpg2)" ] && \
 		gpg2 --version >/dev/null
 	then
-		if [ -s "${startdir}/GPGKEYS" ]; then
+		local gpgkeys
+		for gpgkeys in "${startdir}/GPGKEYS" "${srcdir}/${pkgname}-GPGKEYS"; do
+			[ -s "$gpgkeys" ] || continue
+			msg "Importing from $gpgkeys"
 			gpg2 --homedir "${srcdir}/.gnupg" --quiet \
 				--keyid-format 0xlong \
 				--auto-key-retrieve \
 				--trust-model tofu+pgp \
-				--import "${startdir}/GPGKEYS"
-		fi
+				--key-origin "url,file://${gpgkeys}" \
+				--import "$gpgkeys"
+		done
 
 		local trust fingerprint
 		echo "$gpgfingerprints" | tr ',' '\n' | while IFS=: read -r trust fingerprint; do
@@ -361,6 +365,7 @@ gpg_verify() {
 		local uri filename srcpath gpgverified
 		for uri in $source; do
 			filename="$(filename_from_uri "$uri")"
+			[ "$filename" != "${pkgname}-GPGKEYS" ] || continue
 			srcpath="${srcdir}/${filename}"
 			gpgverified=false
 
@@ -506,6 +511,7 @@ fetch_gpg_signatures() {
 	uri="$1"
 	url="$(url_from_uri "$uri")"
 	filename="$(filename_from_uri "$uri")"
+	[ "$filename" != "${pkgname}-GPGKEYS" ] || return 0
 
 	fetched=false
 	for sigext in $gpg_signature_extensions; do

--- a/abuild.in
+++ b/abuild.in
@@ -304,9 +304,98 @@ md5check() {
 	sumcheck md5 "$md5sums"
 }
 
+gpg_verify() {
+	local allverified
+
+	if [ -n "$source" ] && \
+		[ -n "$gpgfingerprints" ] && \
+		[ -n "$(command -v gpg2)" ] && \
+		gpg2 --version >/dev/null
+	then
+		local trust fingerprint
+		echo "$gpgfingerprints" | tr ',' '\n' | while IFS=: read -r trust fingerprint; do
+			case "$(printf -- '%s' $trust)" in
+				good) trust='good' ;;
+				""|unknown) trust='unknown' ;;
+				*) fingerprint="$trust"; trust='unknown' ;;
+			esac
+			fingerprint="$(printf -- '%s' $fingerprint)"
+			# fingerprint="${fingerprint//[^A-F0-9a-f]}" # not POSIX, but does eliminate GPG errors
+			case "${#fingerprint}" in
+				40) ;;
+				*) continue ;;
+			esac
+
+			# use redirection because no output or errors matter
+			if ! gpg2 >/dev/null 2>&1 --homedir "${srcdir}/.gnupg" \
+				--keyid-format 0xlong \
+				--auto-key-retrieve \
+				--trust-model tofu+pgp \
+				--list-keys "$fingerprint"
+			then
+				gpg2 --homedir "${srcdir}/.gnupg" --quiet \
+					--keyid-format 0xlong \
+					--auto-key-retrieve \
+					--trust-model tofu+pgp \
+					--recv-key "$fingerprint"
+			fi
+
+			# use redirection because --quiet doesn't affect tofu policy logging
+			gpg2 >/dev/null 2>&1 --homedir "${srcdir}/.gnupg" \
+				--keyid-format 0xlong \
+				--auto-key-retrieve \
+				--trust-model tofu+pgp \
+				--tofu-policy "$trust" "$fingerprint"
+		done
+
+		allverified=true
+
+		local uri filename srcpath gpgverified
+		for uri in $source; do
+			filename="$(filename_from_uri "$uri")"
+			srcpath="${srcdir}/${filename}"
+			gpgverified=false
+
+			local sigext
+			for sigext in $gpg_signature_extensions; do
+				local sigfile
+				sigfile="${srcpath}.${sigext}"
+
+				[ -s "$sigfile" ] || continue
+				if gpg2 --homedir "${srcdir}/.gnupg" --verbose \
+					--keyid-format 0xlong \
+					--auto-key-retrieve \
+					--trust-model tofu+pgp \
+					--tofu-default-policy bad \
+					--verify "$sigfile" "$srcpath"
+				then
+					gpgverified=true
+					break
+				fi
+			done
+
+			if ! $gpgverified && is_remote "$uri"; then
+				allverified=false
+				error "${filename} does not have a valid GPG signature"
+			fi
+		done
+
+		if ! $allverified; then
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
 # verify checksums
 verify() {
-	local verified=false algo=
+	local verified
+
+	verified=false
+	gpg_verify
+
+	local algo
 	for algo in sha512 sha256 sha1 md5; do
 		local sums=
 		eval sums=\"\$${algo}sums\"
@@ -354,12 +443,23 @@ is_remote() {
 }
 
 filename_from_uri() {
-	local uri="$1"
-	local filename="${uri##*/}"  # $(basename $uri)
+	local uri filename
+	uri="$1"
+	filename="${uri##*/}"  # $(basename $uri)
 	case "$uri" in
-	*::*) filename=${uri%%::*};;
+	*::*) filename="${uri%%::*}" ;;
 	esac
 	echo "$filename"
+}
+
+url_from_uri() {
+	local uri url
+	uri="$1"
+	case "$uri" in
+	*::*) url="${uri#*::}" ;;
+	*)    url="$uri" ;;
+	esac
+	echo "$url"
 }
 
 # try download from file from mirror first
@@ -389,11 +489,36 @@ symlinksrc() {
 	done
 }
 
+fetch_gpg_signatures() {
+	local fetched filename sigext uri url
+
+	[ -n "$gpgfingerprints" ] || return 0
+	[ -n "$gpg_signature_extensions" ] || return 0
+
+	uri="$1"
+	url="$(url_from_uri "$uri")"
+	filename="$(filename_from_uri "$uri")"
+
+	fetched=false
+	for sigext in $gpg_signature_extensions; do
+		uri_fetch_mirror "${filename}.${sigext}::${url}.${sigext}" && \
+		ln -sf "${SRCDEST}/${filename}.${sigext}" "$srcdir"/ && fetched=true || :
+	done
+
+	if ! $fetched; then
+		warning "Could not fetch any GPG signatures"
+		return 1
+	fi
+
+	return 0
+}
+
 default_fetch() {
 	local s
 	mkdir -p "$srcdir"
 	for s in $source; do
 		if is_remote "$s"; then
+			fetch_gpg_signatures "$s"
 			uri_fetch_mirror "$s" || return 1
 			ln -sf "$SRCDEST/$(filename_from_uri $s)" "$srcdir"/
 		else
@@ -2134,6 +2259,7 @@ checksum() {
 
 	[ -z "$source" ] && return 0
 	fetch
+	gpg_verify
 	for s in $source; do
 		files="$files $(filename_from_uri $s)"
 	done
@@ -2576,6 +2702,7 @@ cd "$startdir" || die
 . "$APKBUILD"
 
 builddir=${builddir:-"$srcdir/$pkgname-$pkgver"}
+gpg_signature_extensions="${gpg_signature_extensions:-sig asc}"
 
 # If REPODEST is set then it will override the PKGDEST
 if [ -z "$REPODEST" ]; then

--- a/abuild.in
+++ b/abuild.in
@@ -373,6 +373,10 @@ gpg_verify() {
 			for sigext in $gpg_signature_extensions; do
 				local sigfile
 				sigfile="${srcpath}.${sigext}"
+				if [ "." = "$sigext" ]; then
+					sigfile="${srcpath}"
+					sigext=""
+				fi
 
 				[ -s "$sigfile" ] || continue
 				if gpg2 --homedir "${srcdir}/.gnupg" --verbose \
@@ -380,7 +384,7 @@ gpg_verify() {
 					--auto-key-retrieve \
 					--trust-model tofu+pgp \
 					--tofu-default-policy bad \
-					--verify "$sigfile" "$srcpath"
+					--verify "$sigfile" ${sigext:+"$srcpath"}
 				then
 					gpgverified=true
 					break
@@ -514,8 +518,9 @@ fetch_gpg_signatures() {
 
 	fetched=false
 	for sigext in $gpg_signature_extensions; do
-		uri_fetch_mirror "${filename}.${sigext}::${url}.${sigext}" && \
-		ln -sf "${SRCDEST}/${filename}.${sigext}" "$srcdir"/ && fetched=true || :
+		[ "." = "$sigext" ] && sigext="" || sigext=".${sigext}"
+		uri_fetch_mirror "${filename}${sigext}::${url}${sigext}" && \
+		ln -sf "${SRCDEST}/${filename}${sigext}" "$srcdir"/ && fetched=true || :
 	done
 
 	if ! $fetched; then

--- a/abuild.in
+++ b/abuild.in
@@ -211,7 +211,7 @@ default_sanitycheck() {
 
 			# verify that our source does not have git tag version
 			# name as tarball (typicallly github)
-			if is_remote "$i" && [ "${i#*::}" = "$i" ]; then
+			if is_remote "$i" && [ "$(url_from_uri "$i")" = "$i" ]; then
 				case ${i##*/} in
 				v$pkgver.tar.*|$pkgver.tar.*)
 					die "source ${i##*/} needs to be renamed to avoid possible collisions"
@@ -430,25 +430,23 @@ sourcecheck() {
 	local uri
 	for uri in $source; do
 		is_remote $uri || continue
-		case "$uri" in
-		*::*)
-			uri=${uri##*::}
-			;;
-		esac
-		wget --spider -q "$uri" || return 1
+		wget --spider -q "$(url_from_uri "$uri")" || return 1
 	done
 	return 0
 }
 
 uri_fetch() {
-	local uri="$1"
+	local uri filename as
+	uri="$1"
+	filename="$(filename_from_uri "$uri")"
+	[ "$filename" != "${uri##*/}" ] && as="$filename" || as=""
 	mkdir -p "$SRCDEST"
-	msg "Fetching $uri"
+	msg "Fetching $(url_from_uri "$uri")${as:+ as $as}"
 	abuild-fetch -d "$SRCDEST" "$uri"
 }
 
 is_remote() {
-	case "${1#*::}" in
+	case "$(url_from_uri "$1")" in
 		http://*|ftp://*|https://*)
 			return 0;;
 	esac


### PR DESCRIPTION
Have the default fetch function gather GPG signatures and verify them against the `gpgfingerprints` list set in the `APKBUILD` file. You may need to install `gnupg` (not `gnupg1`) before testing this, otherwise nothing is expected to happen.

`gpg_signature_extensions` - defaults to `sig` and `asc`, most sources will use one of these
`gpgfingerprints` - format: `[<TRUST>:]<FINGERPRINT>`
- `<TRUST>`: either `good` or `unknown`
- `<FINGERPRINT>`: usually 40 characters of hex copied from GPG output

Added `GPGKEYS` file next to `APKBUILD` for importing GPG keys from the `aports` repository rather than relying on keyservers.

Resolves https://gitlab.alpinelinux.org/alpine/abuild/issues/9016