### PR TITLE
abuild: default_dbg: do not overwrite variables

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1676,25 +1676,26 @@ doc() {
 
 # predefined splitfunc dbg
 default_dbg() {
-	local f
+	local ddbg_binfiles f ddbg_srcdir ddbg_srcfile ddbg_dstdir ddbg_dstfile
 	pkgdesc="$pkgdesc (debug symbols)"
 
-	binfiles=$(scanelf -R "$pkgdir" | grep ET_DYN | sed "s:$pkgdir\/::g" | sed "s:ET_DYN ::g")
-	for f in $binfiles; do
-		srcdir=$(dirname $pkgdir/$f)
-		srcfile=$(basename $pkgdir/$f)
-		dstdir=$(dirname $subpkgdir/usr/lib/debug/$f.debug)
-		dstfile=$(basename $subpkgdir/usr/lib/debug/$f.debug)
-		if [ ! -d $dstdir ] ; then
-			mkdir -p $dstdir
-		fi
-		cd $srcdir
-		local XATTR=$(getfattr --match="" --dump "${srcfile}")
-		${CROSS_COMPILE}objcopy --only-keep-debug $srcfile $dstfile
-		${CROSS_COMPILE}objcopy --add-gnu-debuglink=$dstfile $srcdir/$srcfile
-		mv $dstfile $dstdir
-		${CROSS_COMPILE}strip $srcfile
-		[ -n "$XATTR" ] && { echo "$XATTR" | setfattr --restore=-; }
+	ddbg_binfiles=$(scanelf -R "$pkgdir" | grep ET_DYN | sed "s:$pkgdir\/::g" | sed "s:ET_DYN ::g")
+	for f in $ddbg_binfiles; do
+		ddbg_srcdir=$(dirname "$pkgdir/$f")
+		ddbg_srcfile=$(basename "$pkgdir/$f")
+		ddbg_dstdir=$(dirname "$subpkgdir/usr/lib/debug/$f.debug")
+		ddbg_dstfile=$(basename "$subpkgdir/usr/lib/debug/$f.debug")
+		[ -d "$ddbg_dstdir" ] || mkdir -p "$ddbg_dstdir"
+
+		(
+			cd "$ddbg_srcdir"
+			XATTR=$(getfattr --match="" --dump "${ddbg_srcfile}")
+			${CROSS_COMPILE}objcopy --only-keep-debug "$ddbg_srcfile" "$ddbg_dstfile"
+			${CROSS_COMPILE}objcopy --add-gnu-debuglink="$ddbg_dstfile" "$ddbg_srcdir/$ddbg_srcfile"
+			mv "$ddbg_dstfile" "$ddbg_dstdir"
+			${CROSS_COMPILE}strip "$ddbg_srcfile"
+			[ -n "$XATTR" ] && { echo "$XATTR" | setfattr --restore=-; }
+		)
 	done
 	return 0
 }


### PR DESCRIPTION
srcdir is very important for abuild operation.

Also, quoted various paths and contain directory changes to a subshell