### PR TITLE
abuild: restore use of command -v instead of which and fix ppc64le

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -13,6 +13,7 @@ datadir=@datadir@
 
 abuild_path=$(readlink -f $0)
 git=$(command -v git) || git=true
+gzip=$(which pigz || echo gzip)
 
 if ! [ -f "$datadir/functions.sh" ]; then
 	echo "$datadir/functions.sh: not found" >&2
@@ -1471,7 +1472,6 @@ human_size() {
 
 create_apks() {
 	local file= dir= name= ver= apk= datadir= size=
-	local gzip=$(command -v pigz || echo gzip)
 	getpkgver || return 1
 	if ! options_has "!tracedeps"; then
 		for file in "$pkgbasedir"/.control.*/.PKGINFO; do
@@ -1605,7 +1605,6 @@ check() {
 
 # predefined splitfunc doc
 default_doc() {
-	local gzip=$(which pigz || echo gzip)
 	depends="$depends_doc"
 	pkgdesc="$pkgdesc (documentation)"
 	install_if="docs $pkgname=$pkgver-r$pkgrel"


### PR DESCRIPTION
prior use of "command -v" in default_doc() broke ppc64le because of some arch specific issues with "command -v" in the busybox provided ash interpreter. 

Commit https://github.com/alpinelinux/abuild/commit/57f2830739e31f9c73d2edaf5103502fbdae6822 replaced using "command -v" to "which" in default_doc() to work around the issue.  

Since this isn't optimal this PR is introduced to revert to the use of "command -v" instead of "which". However to make it work correctly with the ppc64le busybox ash interpreter the pigz vs gzip decision is stored in a global variable.