### PR TITLE
Revert "abuild: replace command -v with which to fix build issues"

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1605,7 +1605,7 @@ check() {
 
 # predefined splitfunc doc
 default_doc() {
-	local gzip=$(which pigz || echo gzip)
+	local gzip=$(command -v pigz || echo gzip)
 	depends="$depends_doc"
 	pkgdesc="$pkgdesc (documentation)"
 	install_if="docs $pkgname=$pkgver-r$pkgrel"


### PR DESCRIPTION
This reverts commit 57f2830739e31f9c73d2edaf5103502fbdae6822.

https://github.com/alpinelinux/aports/pull/7203 fixes the original problem the had required the reverted commit