### PR TITLE
newapkbuild: remove obsolete cd statements

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -266,7 +266,6 @@ __EOF__
 	# Create build() function
 	cat >>APKBUILD<<__EOF__
 build() {
-	cd "\$builddir"
 __EOF__
 
 	case "$buildtype" in
@@ -292,7 +291,6 @@ __EOF__
 	# Create check() function
 	cat >>APKBUILD<<__EOF__
 check() {
-	cd "\$builddir"
 __EOF__
 
 	case "$buildtype" in
@@ -310,7 +308,6 @@ __EOF__
 	# Create package() function
 	cat >>APKBUILD<<__EOF__
 package() {
-	cd "\$builddir"
 __EOF__
 
 	case "$buildtype" in


### PR DESCRIPTION
Since `$builddir` is officially supported and abuild automatically cd's to `$builddir`, it does not need to be part of the template anymore.