### PR TITLE
abuild.in: fix warning with gawk-5.0

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -845,7 +845,7 @@ git_last_commit() {
 
 get_maintainer() {
 	if [ -z "$maintainer" ]; then
-		maintainer=$(awk -F': ' '/\# *Maintainer/ {print $2}' "$APKBUILD")
+		maintainer=$(awk -F': ' '/# *Maintainer/ {print $2}' "$APKBUILD")
 		# remove surrounding whitespace
 		maintainer=$(echo "$maintainer" | xargs)
 	fi


### PR DESCRIPTION
awk: cmd. line:1: warning: regexp escape sequence `\#' is not a known regexp operator