### PR TITLE
abuild: default_dbg: do not trigger trap with test failure

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1695,6 +1695,7 @@ default_dbg() {
 			mv "$ddbg_dstfile" "$ddbg_dstdir"
 			${CROSS_COMPILE}strip "$ddbg_srcfile"
 			[ -n "$XATTR" ] && { echo "$XATTR" | setfattr --restore=-; }
+			exit 0
 		)
 	done
 	return 0

--- a/abuild.in
+++ b/abuild.in
@@ -1694,7 +1694,9 @@ default_dbg() {
 			${CROSS_COMPILE}objcopy --add-gnu-debuglink="$ddbg_dstfile" "$ddbg_srcdir/$ddbg_srcfile"
 			mv "$ddbg_dstfile" "$ddbg_dstdir"
 			${CROSS_COMPILE}strip "$ddbg_srcfile"
-			[ -n "$XATTR" ] && { echo "$XATTR" | setfattr --restore=-; }
+			if [ -n "$XATTR" ]; then
+				echo "$XATTR" | setfattr --restore=-
+			fi
 			exit 0
 		)
 	done


### PR DESCRIPTION
This is an interaction between when `[ -n "" ]` has a failing exit status and the `EXIT` trap set in `runpart` taking effect when the sub-shell exits.

We avoid triggering the trap by always exiting with a succeeded exit status from the sub-shell.