### PR TITLE
Fix condition check for adding static libraries to -dev package.

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1719,7 +1719,7 @@ default_dev() {
 			usr/lib/qt*/mkspecs			\
 			usr/lib/cmake				\
 			$(find . -name include -type d)	\
-			$([ -z "${subpackages##*$pkgname-static*}" ] && find $libdirs \
+			$(subpackage_types_has static || find $libdirs \
 				-name '*.a' 2>/dev/null) \
 			$(find $libdirs -name '*.[cho]' \
 				-o -name '*.prl' 2>/dev/null); do


### PR DESCRIPTION
This was the wrong way, we only want to add the static library to the
-dev package when there isn't a -static package.