### PR TITLE
Fix regression from "newapkbuild: remove obsolete cd statements "

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -104,6 +104,13 @@ build_python() {
 __EOF__
 }
 
+build_empty() {
+	cat >>APKBUILD<<__EOF__
+	# Replace with proper build command(s)
+	:
+__EOF__
+}
+
 check_make() {
 	cat >>APKBUILD<<__EOF__
 	make check
@@ -113,6 +120,13 @@ __EOF__
 check_python() {
 	cat >>APKBUILD<<__EOF__
 	python3 setup.py test
+__EOF__
+}
+
+check_empty() {
+	cat >>APKBUILD<<__EOF__
+	# Replace with proper check command(s)
+	:
 __EOF__
 }
 
@@ -143,6 +157,13 @@ __EOF__
 package_python() {
 	cat >>APKBUILD<<__EOF__
 	python3 setup.py install --prefix=/usr --root="\$pkgdir"
+__EOF__
+}
+
+package_empty() {
+	cat >>APKBUILD<<__EOF__
+	# Replace with proper package command(s)
+	:
 __EOF__
 }
 
@@ -281,6 +302,8 @@ __EOF__
 		build_perl;;
 	python)
 		build_python;;
+	*)
+		build_empty;;
 	esac
 
 	cat >>APKBUILD<<__EOF__
@@ -298,6 +321,8 @@ __EOF__
 		check_make;;
 	python)
 		check_python;;
+	*)
+		check_empty;;
 	esac
 
 	cat >>APKBUILD<<__EOF__
@@ -321,6 +346,8 @@ __EOF__
 		package_perl;;
 	python)
 		package_python;;
+	*)
+		package_empty;;
 	esac
 
 	if [ -n "$cpinitd" ]; then

--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -111,6 +111,7 @@ build_empty() {
 __EOF__
 }
 
+# Check sections
 check_make() {
 	cat >>APKBUILD<<__EOF__
 	make check


### PR DESCRIPTION
Since the obsolete 'cd "$builddir"' statements have been removed in f83d19ce79ab9f2dcc5238346a910cd18ae0f330, build(), check() and package() can generate empty functions if no build system is specified or if there is no default for the given build system. newapkbuild will then fail, as it tries to parse the script it generated:

```
$ cd /home/pmos && newapkbuild test
/usr/bin/abuild: /home/pmos/test/APKBUILD: line 18: syntax error: unexpected "}"
$ cat test/APKBUILD
...
build() {
}
...
```
Fix this by placing "true" in functions that would be empty.