### PR TITLE
newapkbuild: quote pkgname and pkgver

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -213,8 +213,8 @@ newaport() {
 	cat >APKBUILD<<__EOF__
 # Contributor:${PACKAGER:+" "}${PACKAGER}
 # Maintainer:${MAINTAINER:+" "}${MAINTAINER}
-pkgname=$pkgname
-pkgver=$pv
+pkgname="$pkgname"
+pkgver="$pv"
 pkgrel=0
 pkgdesc="$pkgdesc"
 url="$url"


### PR DESCRIPTION
These are strings after all and should be quoted even if not strictly necessary because of tradition excluding spaces from package names.