### PR TITLE
newapkbuild: use current directory for cmake

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -68,7 +68,7 @@ build_cmake() {
 		-DCMAKE_BUILD_TYPE=Release \\
 		-DCMAKE_CXX_FLAGS="\$CXXFLAGS" \\
 		-DCMAKE_C_FLAGS="\$CFLAGS" \\
-		\${CMAKE_CROSSOPTS}
+		\${CMAKE_CROSSOPTS} .
 	make
 __EOF__
 }


### PR DESCRIPTION
When using `newpkgbuild` to create a CMake APKBUILD, the default build will give this warning when running CMake:

```
CMake Warning:
  No source or binary directory provided.  Both will be assumed to be the
  same as the current working directory, but note that this warning will
  become a fatal error in future CMake releases.
```
This commit explicitly specifies the current directory in order to prevent a fatal error down the track, and to silence the warning.