### PR TITLE
newapkbuild: add py3-setuptools to python apkbuild

### DIFF
--- a/newapkbuild.in
+++ b/newapkbuild.in
@@ -185,7 +185,7 @@ newaport() {
 	fi
 
 	case "$buildtype" in
-	python) makedepends="python3-dev";;
+	python) makedepends="python3-dev py3-setuptools";;
 	cmake)  makedepends="cmake";;
 	meson)  makedepends="meson";;
 	*)      makedepends="\$depends_dev";;


### PR DESCRIPTION
Seeing as the default python build/check/package apkbuild functions call `setup.py` and that relies on `py3-setuptools`, perhaps it should be added to the makedepends.

Inspiration from https://github.com/alpinelinux/aports/pull/7641#pullrequestreview-234326397