### PR TITLE
Better use license.lst in abuild sanitycheck

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -873,7 +873,7 @@ check_license() {
 	fi
 	local i; for i in $license; do
 		list_has "$i" $exclude && continue
-		if ! grep -q -w -F "$i" "$license_list"; then
+		if ! grep -q -x -F "$i" "$license_list"; then
 			ret=1
 			warning "\"$i\" is not a known license"
 		fi


### PR DESCRIPTION
Before this change an invalid `licence=` in an `APKBUILD` will pass `abuild
sanitycheck`. `/usr/share/spdx/license.lst` contains one licence per line.
`grep -x` will match partial lines whereas `grep -w` will only match whole
lines.


A simple demonstration is with 'GPL-3.0' which is not a valid SPDX licence
identifier. 'GPL-3.0-only' and 'GPL-3.0-or-later' are valid licences. 

```
$ grep --help
BusyBox v1.30.1 (2019-04-26 06:26:16 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsriwFE] [-m N] [-A/B/C N] PATTERN/-e PATTERN.../-f FILE [FILE]...

Search for PATTERN in FILEs (or stdin)

✂
        -w      Match whole words only
        -x      Match whole lines only
✂
$ grep -w -F GPL-3.0 /usr/share/spdx/license.lst
GPL-3.0-only
GPL-3.0-or-later
$ grep -x -F GPL-3.0 /usr/share/spdx/license.lst
$
```