### PR TITLE
APKBUILD.5: match install_if example to abuild.in

### DIFF
--- a/APKBUILD.5
+++ b/APKBUILD.5
@@ -158,9 +158,9 @@ should automatically install the package (or subpackage).
 For instance, the OpenRC subpackages set
 .Cm install_if
 to
-.Li $pkgname=$pkgver openrc
-which means that the OpenRC subpackage will be automatically installed if the
-origin package and OpenRC are both installed on the same computer.
+.Li openrc ${subpkgname%-openrc}=$pkgver-r$pkgrel
+which means that the OpenRC subpackage will be automatically installed if
+both OpenRC and the origin package are installed on the same computer.
 .It Cm makedepends
 Specifies build dependencies for the package.
 .It Cm pkggroups


### PR DESCRIPTION
This change makes the example in the description of install_if in the APKBUILD man page match abuild.in:1791.