### PR TITLE
abuild usage fix: fetch does not verify sources

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -2530,7 +2530,7 @@ usage() {
 		  cleanoldpkg Remove binary packages except current version
 		  cleanpkg    Remove already built binary and source package
 		  deps        Install packages listed in makedepends and depends
-		  fetch       Fetch sources to \$SRCDEST and verify checksums
+		  fetch       Fetch sources to \$SRCDEST (consider: 'abuild fetch verify')
 		  index       Regenerate indexes in \$REPODEST
 		  listpkg     List target packages
 		  package     Install project into $pkgdir


### PR DESCRIPTION
Replace text in usage description of fetch that claims to verify sources
with a suggestion to use 'abuild fetch verify', which will actually
verify them.

'abuild fetch' alone will not verify sources, as it only executes the
fetch() function.