### PR TITLE
abuild.in: fixup flags and usage text

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -103,7 +103,7 @@ cleanup() {
 		pkgdir) msg "Cleaning up pkgdir"; rm -rf "$pkgbasedir";;
 		srcdir) msg "Cleaning up srcdir"; cleanup_srcdir;;
 		deps)
-			if [ -z "$install_after" ] && [ -n "$uninstall_after" ]; then
+			if [ -n "$uninstall_after" ]; then
 				msg "Uninstalling dependencies..."
 				undeps
 			fi
@@ -2509,7 +2509,6 @@ usage() {
 		 -f  Force specified cmd (skip checks: apk up to date, arch, libc)
 		 -F  Force run as root
 		 -h  Show this help
-		 -i  Install PKG after successful build
 		 -k  Keep built packages, even if APKBUILD or sources are newer
 		 -K  Keep buildtime temp dirs and files (srcdir/pkgdir/deps)
 		 -m  Disable colors (monochrome)
@@ -2557,7 +2556,7 @@ usage() {
 APKBUILD="${APKBUILD:-./APKBUILD}"
 unset force
 unset recursive
-while getopts "AcdD:fFhkKimnp:P:qrRs:uv" opt; do
+while getopts ":AcdD:fFhkKmnP:qrRs:uv" opt; do
 	case $opt in
 		'A') echo "$CARCH"; exit 0;;
 		'c') enable_colors
@@ -2580,6 +2579,7 @@ while getopts "AcdD:fFhkKimnp:P:qrRs:uv" opt; do
 		'u') upgrade="-u"
 		     recursive="-R";;
 		'v') set -x;;
+		'?') die "Unrecognized option: $OPTARG";;
 	esac
 done
 shift $(( $OPTIND - 1 ))


### PR DESCRIPTION
I'm not sure if this was intentional, but the 'getopts' loop still accepts '-i' and '-p' even though these options provide no functionality. 

If this is intentional, perhaps I could change my PR to just add a comment about this.