### PR TITLE
change ~ to $HOME

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -2616,9 +2616,9 @@ builddir=${builddir:-"$srcdir/$pkgname-$pkgver"}
 
 # If REPODEST is set then it will override the PKGDEST
 if [ -z "$REPODEST" ]; then
-	warning "REPODEST is not set and is now required. Defaulting to ~/packages"
+	warning "REPODEST is not set and is now required. Defaulting to $HOME/packages"
 	[ -n "$PKGDEST" ] && die "PKGDEST is no longer supported."
-	REPODEST="~/packages"
+	REPODEST="$HOME/packages"
 fi
 
 # for recursive action


### PR DESCRIPTION
There is an expansion issue in update_abuildrepo_index where it tries to `cd` into a directory literally starting with a `~`