### PR TITLE
feat: add amove

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -70,6 +70,32 @@ error() {
 	logcmd "ERROR: $pkgname: $1"
 }
 
+amove() {
+	[ -n "${1##/*}"   ] || set "${1#/}" "$2"
+	[ -n "$subpkgdir" ] || return 1
+	[ -e "$pkgdir/$1" ] || return 1
+
+	# store directory
+	d="$(pwd -L)"
+
+	cd "$pkgdir"
+	if [ -n "$2" ]; then # find mode
+		mkdir -p "$subpkgdir/$1"
+		find "$1" ! -path "$1" -prune ! -type d -name "$2" \
+			-exec mv '{}' "$subpkgdir/$1/" \;
+	else # file/dir mode
+		mkdir -p "$subpkgdir/${1%/*}"
+		mv "$1" "$subpkgdir/${1%/*}"
+	fi
+
+	# cleanup
+	rmdir -p "$1" || true
+	rmdir -p "${1%/*}" || true
+	cd "$subpkgdir"
+	rmdir -p "$1" || true
+	cd "$d"
+}
+
 cross_creating() {
 	test "$CHOST" != "$CTARGET" -a -n "$CBUILDROOT"
 }


### PR DESCRIPTION
Amove is a utility function for subpackage splitting.
It takes up to 2 arguments:
$1 is a relative directory (or file)
$2 (optional) is a regex-like format, as taken by find(1p)/-name

If only $1 is specified, it will move $1 from pkgdir to subpkgdir,
creating what is needed and cleaning up after itself appropriately.
If $2 is specified, $1 should be a directory (not checked - unneeded).
When $2 is specified and $1 is a directory, all files directly inside of
$1 that match the $2 namespec will be copied instead.