### PR TITLE
abuild: add SOURCE_DATE_EPOCH support

### DIFF
--- a/abuild-sign.in
+++ b/abuild-sign.in
@@ -31,6 +31,11 @@ do_sign() {
 		cd "$repo"
 		sig=".SIGN.RSA.$keyname"
 		$openssl dgst -sha1 -sign "$privkey" -out "$sig" "$i"
+
+		if [ -n "$SOURCE_DATE_EPOCH" ]; then
+			touch -h -d "@$SOURCE_DATE_EPOCH" "$sig"
+		fi
+
 		tmptargz=$(mktemp)
 		tar -f - -c "$sig" | abuild-tar --cut | gzip -9 > "$tmptargz"
 		tmpsigned=$(mktemp)

--- a/abuild.in
+++ b/abuild.in
@@ -29,6 +29,11 @@ fi
 
 apk_opt_wait="--wait 30"
 
+if [ -z "$SOURCE_DATE_EPOCH" ]; then
+	SOURCE_DATE_EPOCH=$(date -u "+%s")
+fi
+export SOURCE_DATE_EPOCH
+
 umask 022
 
 # run optional log command for remote logging
@@ -936,7 +941,7 @@ prepare_metafiles() {
 	[ ! -d "$dir" ] && die "Missing $dir"
 	cd "$dir"
 	mkdir -p "$controldir"
-	local builddate=$(date -u "+%s")
+	local builddate="$SOURCE_DATE_EPOCH"
 
 	# Fix package size on several filesystems
 	case "$(df -PT . | awk 'END {print $2}')" in
@@ -957,7 +962,7 @@ prepare_metafiles() {
 	if [ -n "$FAKEROOTKEY" ]; then
 		echo "# using $($FAKEROOT -v)" >> "$pkginfo"
 	fi
-	echo "# $(date -u)" >> "$pkginfo"
+	echo "# $(date -u -d @$SOURCE_DATE_EPOCH)" >> "$pkginfo"
 	cat >> "$pkginfo" <<-EOF
 		pkgname = $name
 		pkgver = $pkgver-r$pkgrel
@@ -1521,12 +1526,17 @@ create_apks() {
 			touch .dummy
 			set -- .dummy
 		fi
+
+		# normalize timestamps
+		find . -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+
 		tar --xattrs -f - -c "$@" | abuild-tar --hash | $gzip -9 >"$dir"/data.tar.gz
 
 		msg "Create checksum..."
 		# append the hash for data.tar.gz
 		local sha256=$(sha256sum "$dir"/data.tar.gz | cut -f1 -d' ')
 		echo "datahash = $sha256" >> "$dir"/.PKGINFO
+		touch -h -d "@$SOURCE_DATE_EPOCH" "$dir"/.PKGINFO
 
 		# control.tar.gz
 		cd "$dir"


### PR DESCRIPTION
This uses build dates from SOURCE_DATE_EPOCH if set and normalizes file timestamps in the final apk file.