### PR TITLE
feat: add support for ccache

### DIFF
--- a/abuild.conf
+++ b/abuild.conf
@@ -9,6 +9,9 @@ export MAKEFLAGS=-j$JOBS
 # remove line below to disable colors
 USE_COLORS=1
 
+# uncomment line below to enable ccache support.
+#USE_CCACHE=1
+
 SRCDEST=/var/cache/distfiles
 
 # uncomment line below to store built packages in other location

--- a/abuild.in
+++ b/abuild.in
@@ -26,6 +26,8 @@ fi
 : ${APK:="apk"}
 : ${ADDUSER:="abuild-adduser"}
 : ${ADDGROUP:="abuild-addgroup"}
+: ${CC:="gcc"}
+: ${CXX:="g++"}
 
 apk_opt_wait="--wait 30"
 
@@ -2043,6 +2045,9 @@ builddeps() {
 	mhd=$(get_missing_deps "--root $CBUILDROOT --arch $CTARGET_ARCH" $hostdeps) || return 1
 	missing=$(echo $mbd $mhd)
 
+	# shall ccache be added?
+	[ -n "$USE_CCACHE" ] && missing="$missing ccache"
+
 	if [ -z "$install_deps" ]; then
 		# if we dont have any missing deps we are done now
 		[ -z "$missing" ] && return 0
@@ -2127,6 +2132,7 @@ rootbld() {
 		"$BUILD_ROOT/$SRCDEST" "$BUILD_ROOT/$REPODEST" \
 		"$BUILD_ROOT/tmp/pkg" "$BUILD_ROOT/tmp/src" \
 		"$BUILD_ROOT/usr/bin" "$pkgbasedir" "$REPODEST" \
+		"$BUILD_ROOT/$HOME/.ccache" \
 		"$srcdir"
 
 	cp /etc/abuild.conf /etc/group /etc/passwd "$BUILD_ROOT/etc"
@@ -2159,7 +2165,7 @@ rootbld() {
 
 	calcdeps
 	$SUDO_APK add --initdb --root "$BUILD_ROOT" --update \
-		abuild alpine-base build-base git $hostdeps $builddeps
+		abuild alpine-base build-base git ccache $hostdeps $builddeps
 
 	local bwrap_opts=""
 	options_has "net" || bwrap_opts="$bwrap_opts --unshare-net"
@@ -2170,6 +2176,7 @@ rootbld() {
 		--bind "$BUILD_ROOT/$HOME" "$HOME" \
 		--ro-bind "$HOME/.abuild" "$HOME/.abuild" \
 		--ro-bind "$aportsgit" "$aportsgit" \
+		--bind "$HOME/.ccache" "$HOME/.ccache" \
 		--bind "$SRCDEST" "$SRCDEST" \
 		--bind "$BUILD_ROOT/tmp" /tmp \
 		--bind "$BUILD_ROOT/tmp/src" "$srcdir" \
@@ -2480,6 +2487,24 @@ if [ $(id -u) -eq 0 ] && [ -z "$FAKEROOTKEY" ]; then
 	FAKEROOT=
 fi
 
+# check for ccache presence and maybe export its path
+if [ -n "$USE_CCACHE" ]; then
+	if ! command -v ccache >/dev/null; then
+		die "Ccache is enabled; however, the binary can not be found."
+	fi
+
+	if [ ! -d "$HOME/.ccache" ]; then
+		die "Ccache is enabled; however, the user cache directory is not found."
+	fi
+
+	if [ ! -f "$HOME/.ccache/ccache.conf" ]; then
+		die "Ccache is enabled; however, the ccache configuration file is not found."
+	fi
+
+	# prepend ccache path
+	export PATH="/usr/lib/ccache/bin:$PATH"
+fi
+
 # find startdir
 [ -f "$APKBUILD" ] || die "Could not find $APKBUILD (PWD=$PWD)"
 APKBUILD=$(readlink -f "$APKBUILD")
@@ -2498,9 +2523,7 @@ SRCDEST=${SRCDEST:-$startdir}
 
 BUILD_ROOT=
 
-# set a default CC
-: ${CC:=gcc}
-export CC
+export CC CXX
 
 cd "$startdir" || die
 . "$APKBUILD"

--- a/functions.sh.in
+++ b/functions.sh.in
@@ -55,7 +55,7 @@ hostspec_to_libc() {
 readconfig() {
 	local _APORTSDIR _BUILDDIR _PKGDEST _SRCPKGDEST _REPODEST _SRCDEST
 	local _CARCH _CHOST _CTARGET _CPPFLAGS _CFLAGS _CXXFLAGS _LDFLAGS
-	local _JOBS _MAKEFLAGS _PACKAGER _USE_COLORS
+	local _JOBS _MAKEFLAGS _PACKAGER _USE_COLORS _USE_CCACHE
 	local gitbase=
 	[ -n "${APORTSDIR+x}" ] && _APORTSDIR=$APORTSDIR
 	[ -n "${BUILDDIR+x}" ] && _BUILDDIR=$BUILDDIR
@@ -74,6 +74,7 @@ readconfig() {
 	[ -n "${MAKEFLAGS+x}" ] && _MAKEFLAGS=$MAKEFLAGS
 	[ -n "${PACKAGER+x}" ] && _PACKAGER=$PACKAGER
 	[ -n "${USE_COLORS+x}" ] && _USE_COLORS="$USE_COLORS"
+	[ -n "${USE_CCACHE+x}" ] && _USE_CCACHE="$USE_CCACHE"
 	: ${ABUILD_CONF:=$sysconfdir/abuild.conf}
 	: ${ABUILD_USERDIR:=$HOME/.abuild}
 	: ${ABUILD_USERCONF:=$ABUILD_USERDIR/abuild.conf}
@@ -113,6 +114,7 @@ readconfig() {
 	MAKEFLAGS=${_MAKEFLAGS-$MAKEFLAGS}
 	PACKAGER=${_PACKAGER-$PACKAGER}
 	USE_COLORS=${_USE_COLORS-$USE_COLORS}
+	USE_CCACHE=${_USE_CCACHE-$USE_CCACHE}
 
 	[ -z "$CBUILD" ] && CBUILD="$(gcc -dumpmachine)"
 	[ -z "$CHOST" ] && CHOST="$CBUILD"


### PR DESCRIPTION
This introduces basic support for ccache, during packaging builds.

If you are building many packages, it is recommended to manually
increase the maximum size of the ccache cache. This is typically
achieved by modifying `~/.ccache/ccache.conf` and adjusting the
`max_size` setting.

Signed-off-by: Joseph Benden <joe@benden.us>