### PR TITLE
Make SPDX detection more accurate.

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -873,7 +873,7 @@ check_license() {
 	fi
 	local i; for i in $license; do
 		list_has "$i" $exclude && continue
-		if ! grep -q -w -F "$i" "$license_list"; then
+		if ! grep -q "^$i$" "$license_list"; then
 			ret=1
 			warning "\"$i\" is not a known license"
 		fi


### PR DESCRIPTION
Use ^ $ to check a full line when searching for a valid license