### PR TITLE
abuild: rename makedepends_host virtual package

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -2424,7 +2424,7 @@ deps() {
 	if [ -n "$CBUILDROOT" ]; then
 		[ -z "$_quiet" ] && msg "Installing for host:$hostdeps"
 		$SUDO_APK add $_quiet --root "$CBUILDROOT" --arch "$CTARGET_ARCH" --repository "$REPODEST/$repo" $apk_opt_wait \
-			--no-scripts --virtual .makedepends-$pkgname $hostdeps || return 1
+			--no-scripts --virtual .hostdepends-$pkgname $hostdeps || return 1
 	fi
 }
 
@@ -2433,7 +2433,7 @@ undeps() {
 	$SUDO_APK del $_quiet $apk_opt_wait .makedepends-$pkgname || :
 	if [ -n "$CBUILDROOT" ]; then
 		$SUDO_APK del $_quiet --root "$CBUILDROOT" --arch "$CTARGET_ARCH" $apk_opt_wait \
-			--no-scripts .makedepends-$pkgname || :
+			--no-scripts .hostdepends-$pkgname || :
 	fi
 }
 


### PR DESCRIPTION
With a recent change in apk [1], virtual packages of the same name will
upgrade each other. Adjust abuild to this by not using the same virtual
package name for two types of dependencies.

This fixes the way crosscompilers are built in postmarketOS [2], which
is essentially the same as running this on Alpine's gcc aport:
```
$ cd aports/main/gcc
$ C_TARGET_ARCH=armhf CTARGET=armv6-alpine-linux-musleabihf \
  BOOTSTRAP=nobuildbase CBUILDROOT=/ abuild -r
...
>>> gcc-armhf: Installing for host:
(1/24) Upgrading .makedepends-gcc-armhf (20190714.104731 -> 20190714.104741)
(2/24) Purging binutils-armhf (2.31.1-r2)
...
```

[1] https://github.com/alpinelinux/apk-tools/commit/37fbafcd928c466c82c892a7868d686d710e5d07
[2] https://gitlab.com/postmarketOS/pmaports/blob/master/cross/gcc-armhf/APKBUILD

Fixes: https://gitlab.alpinelinux.org/alpine/apk-tools/issues/10649


CC: @fabled 