### PR TITLE
Add support for creating pyX.Y providers

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1109,6 +1109,39 @@ prepare_command_provides() {
 	done
 }
 
+prepare_py_provides() {
+	local dir="${subpkgdir:-$pkgdir}"
+	options_has "!tracedeps" && return 0
+	cd "$dir" || return 1
+
+	# Find all directories under site-packages, ignore __pycache__ and
+	# .egg-info packages
+	find 'usr/lib/python'*/site-packages/* \
+		-type d \
+		-not -iname __pycache__ \
+		-and \
+		-not -iname '*.egg-info' \
+		-and \
+		-not -iname '*.dist-info' \
+		-prune \
+		2>/dev/null | while read -r d; do
+		# Replace /usr/lib/pythonX.Y/site-packages/foo with pyX.Y: foo
+		d="$(echo $d | sed 's|.*python\([0-9].*[0-9]\)/site-packages/|py\1:|g')"
+		echo $d >> "$controldir"/.provides-py
+	done
+
+	# Also deal with one-file packages that install into site-packages itself
+	for f in usr/lib/python*/site-packages/*.py; do
+		if ! [ -f "$f" ]; then
+			continue
+		fi
+
+		f="$(echo $f | sed 's|.*python\([0-9].*[0-9]\)/site-packages/\(.*\).py|py\1:\2|g')"
+		echo $f >> "$controldir"/.provides-py
+	done
+
+}
+
 # check if dir has arch specific binaries
 dir_has_arch_binaries() {
 	local dir="$1"
@@ -1163,6 +1196,7 @@ prepare_package() {
 		&& prepare_symlinks \
 		&& prepare_pkgconfig_provides \
 		&& prepare_command_provides \
+		&& prepare_py_provides \
 		|| return 1
 	archcheck
 }
@@ -1312,6 +1346,10 @@ trace_apk_deps() {
 	fi
 	if [ -f "$dir"/.provides-command ]; then
 		sed 's/^/provides = cmd:/' "$dir"/.provides-command | sort -u \
+			>> "$dir"/.PKGINFO
+	fi
+	if [ -f "$dir"/.provides-py ]; then
+		sed 's/^/provides = /' "$dir"/.provides-py | sort -u \
 			>> "$dir"/.PKGINFO
 	fi
 	[ -z "$autodeps" ] && return 0


### PR DESCRIPTION
Now all python packages that install to site-packages have the packages
they provide tracked via the pyX.Y: provides.

Each directory and its descendent directories under
usr/lib/pythonX.Y/site-packages are converted into a pyX.Y provider.

Examples:

- 1 directory is converted into a name
usr/lib/python3.7/site-packages/foo -> py3.7:foo

- 1 file ending with .py converted to a name
usr/lib/python3.7/site-packages/foo.py -> py3.7:foo

- 1 descendent directory is converted to a name, the forward-slash
 is converted to a dot since that is the convention python uses
usr/lib/python3.7/site-packages/foo/sub -> py3.7:foo.sub


NOTE: This still doesn't create a workflow for detecting and adding
 dependencies to the pyX.Y: providers.