### PR TITLE
abuild: -static depends on -dev by default

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1767,7 +1767,23 @@ dev() {
 
 # predefined splitfunc static
 default_static() {
-	local i=
+	local i= devpkg
+
+	# search for -dev package matching our prefix
+	if [ -z "$depends_static" ]; then
+		# remove common suffixes to get our prefix
+		for devpkg in \
+		    "${subpkgname%-static}" \
+		    "${subpkgname%-libs-static}" \
+		    ;
+		do
+			devpkg="$devpkg-dev"
+			if subpackages_has "$devpkg"; then
+				depends_static="$devpkg"
+			fi
+		done
+	fi
+
 	depends="$depends_static"
 	pkgdesc="$pkgdesc (static library)"
 


### PR DESCRIPTION
When you have `-dev` and install `-libs-static`, for example,
it helps to only need to add one to `makedepends` instead of both.