### PR TITLE
Fix package version check on checkapk

### DIFF
--- a/checkapk.in
+++ b/checkapk.in
@@ -67,7 +67,7 @@ for i in $pkgname $subpackages; do
 	# generate a temp repositories file with only the http(s) repos
 	grep -E "^https?:" /etc/apk/repositories > $tmpdir/repositories
 
-	oldpkg=$(apk fetch --repositories-file $tmpdir/repositories --simulate 2>&1 | sed 's/^Downloading //')
+	oldpkg=$(apk fetch --repositories-file $tmpdir/repositories --simulate $_pkgname 2>&1 | sed 's/^Downloading //')
 	if [ "${oldpkg}" = "${pkg}" ]; then
 		die "the built package ($_pkgname) is already in the repo"
 	fi


### PR DESCRIPTION
The assignment of the oldpkg variable is missing the name of the package