### PR TITLE
Fix remaining reproducible builds issues in abuild

### DIFF
--- a/abuild.in
+++ b/abuild.in
@@ -1579,7 +1579,11 @@ create_apks() {
 		# normalize timestamps
 		find . -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
 
-		tar --xattrs -f - -c "$@" | abuild-tar --hash | $gzip -9 >"$dir"/data.tar.gz
+		tar --xattrs \
+			--format=posix \
+			--pax-option=exthdr.name=%d/PaxHeaders/%f,atime:=0,ctime:=0 \
+			--mtime="@${SOURCE_DATE_EPOCH}" \
+			-f - -c "$@" | abuild-tar --hash | $gzip -n -9 >"$dir"/data.tar.gz
 
 		msg "Create checksum..."
 		# append the hash for data.tar.gz
@@ -1589,8 +1593,12 @@ create_apks() {
 
 		# control.tar.gz
 		cd "$dir"
-		tar -f - -c $(cat "$dir"/.metafiles) | abuild-tar --cut \
-			| $gzip -9 > control.tar.gz
+		tar \
+			--format=posix \
+			--pax-option=exthdr.name=%d/PaxHeaders/%f,atime:=0,ctime:=0 \
+			--mtime="@${SOURCE_DATE_EPOCH}" \
+			-f - -c $(cat "$dir"/.metafiles) | abuild-tar --cut \
+			| $gzip -n -9 > control.tar.gz
 		abuild-sign -q control.tar.gz || exit 1
 
 		msg "Create $apk"
@@ -1724,7 +1732,7 @@ default_doc() {
 			fi
 		done
 
-		[ $islink -eq 0 ] && $gzip -9 "$name"
+		[ $islink -eq 0 ] && $gzip -n -9 "$name"
 	done
 
 	rm -f "$subpkgdir/usr/share/info/dir"

--- a/abuild.in
+++ b/abuild.in
@@ -1577,13 +1577,15 @@ create_apks() {
 		fi
 
 		# normalize timestamps
-		find . -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+		find "$@" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
 
-		tar --xattrs \
+		# explicitly sort package content
+		find "$@" -print0 | LC_ALL=C sort -z | tar --xattrs \
 			--format=posix \
 			--pax-option=exthdr.name=%d/PaxHeaders/%f,atime:=0,ctime:=0 \
 			--mtime="@${SOURCE_DATE_EPOCH}" \
-			-f - -c "$@" | abuild-tar --hash | $gzip -n -9 >"$dir"/data.tar.gz
+			--no-recursion --null -T - \
+			-f - -c | abuild-tar --hash | $gzip -n -9 >"$dir"/data.tar.gz
 
 		msg "Create checksum..."
 		# append the hash for data.tar.gz


### PR DESCRIPTION
- ensures that `gzip -n` is always used
- normalizes atime and ctime in tar metadata
- explicitly sort the files instead of relying on the order returned by readdir(2)